### PR TITLE
Only apply service settings when going live

### DIFF
--- a/src/nodeobs_service.cpp
+++ b/src/nodeobs_service.cpp
@@ -2062,7 +2062,12 @@ void OBS_service::updateStreamSettings(void)
 	if(strcmp(currentOutputMode, "Simple") == 0) {
         OBS_service::updateVideoStreamingEncoder();
 	} else if (strcmp(currentOutputMode, "Advanced") == 0) {
+		bool applyServiceSettings = config_get_bool(config, "AdvOut", "ApplyServiceSettings");
 
+		if (applyServiceSettings) {
+			obs_data_t* encoderSettings = obs_encoder_get_settings(videoStreamingEncoder);
+			obs_service_apply_encoder_settings(OBS_service::getService(), encoderSettings, nullptr);
+		}
     }
 
     resetVideoContext("Stream");

--- a/src/nodeobs_settings.cpp
+++ b/src/nodeobs_settings.cpp
@@ -2247,14 +2247,9 @@ void OBS_settings::saveAdvancedOutputStreamingSettings(Local<Array> settings, st
 	if (ret != 0) {
 		blog(LOG_WARNING, "Failed to config file %s", basicConfigFile.c_str());
 	}
-	
-	bool applyServiceSettings = config_get_bool(config, "AdvOut", "ApplyServiceSettings");
 
-	if (applyServiceSettings)
-		obs_service_apply_encoder_settings(OBS_service::getService(), encoderSettings, nullptr);
-	
 	obs_encoder_update(encoder, encoderSettings);
-	
+
 	std::string path = OBS_API::getStreamingEncoderConfigPath();
 	if (!obs_data_save_json_safe(encoderSettings, path.c_str(), "tmp", "bak")) {
 		blog(LOG_WARNING, "Failed to save encoder %s", path.c_str());


### PR DESCRIPTION
Replication if the OBS behavior. The users will have the possibility to change their stream encoder settings even if they have the apply service encoder settings set to true.