### PR TITLE
Fix rare crash on SSE capable computers (everyone)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,10 @@ SET(PROJECT_SOURCE
 	"src/nodeobs_obspp_manager.hpp" "src/nodeobs_obspp_manager.cpp"
 	"src/nodeobs_obspp_index.hpp" "src/nodeobs_obspp_index.cpp"
 	"src/nodeobs_content.h"
+	"src/gs-limits.h"
+	"src/gs-vertex.h" "src/gs-vertex.cpp"
+	"src/gs-vertexbuffer.h" "src/gs-vertexbuffer.cpp"
+	"src/util-memory.h" "src/util-memory.cpp"
 )
 SET(PROJECT_LIBRARIES
 	${CMAKE_JS_LIB}

--- a/src/gs-limits.h
+++ b/src/gs-limits.h
@@ -1,0 +1,26 @@
+/*
+* Modern effects for a modern Streamer
+* Copyright (C) 2017 Michael Fabian Dirks
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+*/
+
+#pragma once
+#include <inttypes.h>
+
+namespace GS {
+	static const uint32_t MAXIMUM_VERTICES = 0xFFFFFFu;
+	static const uint32_t MAXIMUM_UVW_LAYERS = 8u;
+}

--- a/src/gs-vertex.cpp
+++ b/src/gs-vertex.cpp
@@ -1,0 +1,48 @@
+/*
+ * Modern effects for a modern Streamer
+ * Copyright (C) 2017 Michael Fabian Dirks
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ */
+
+#include "gs-vertex.h"
+#include "util-memory.h"
+
+GS::Vertex::Vertex() {
+	this->hasStore = true;
+	this->store = util::malloc_aligned(16, sizeof(vec3) * 3 + sizeof(uint32_t) + sizeof(vec4)*MAXIMUM_UVW_LAYERS);
+	this->position = reinterpret_cast<vec3*>(store);
+	this->normal = reinterpret_cast<vec3*>(reinterpret_cast<char*>(store) + (16 * 1));
+	this->tangent = reinterpret_cast<vec3*>(reinterpret_cast<char*>(store) + (16 * 2));
+	for (size_t n = 0; n < MAXIMUM_UVW_LAYERS; n++) {
+		this->uv[n] = reinterpret_cast<vec4*>(reinterpret_cast<char*>(store) + (16 * (2 + n)));
+	}
+	this->color = reinterpret_cast<uint32_t*>(reinterpret_cast<char*>(store) + (16 * (3 + MAXIMUM_UVW_LAYERS)));
+}
+
+GS::Vertex::~Vertex() {
+	if (hasStore)
+		util::free_aligned(store);
+}
+
+GS::Vertex::Vertex(vec3* p, vec3* n, vec3* t, uint32_t* col, vec4* uvs[MAXIMUM_UVW_LAYERS])
+	: position(p), normal(n), tangent(t), color(col) {
+	if (uvs != nullptr) {
+		for (size_t idx = 0; idx < MAXIMUM_UVW_LAYERS; idx++) {
+			this->uv[idx] = uvs[idx];
+		}
+	}
+	this->hasStore = false;
+}

--- a/src/gs-vertex.h
+++ b/src/gs-vertex.h
@@ -1,0 +1,47 @@
+/*
+ * Modern effects for a modern Streamer
+ * Copyright (C) 2017 Michael Fabian Dirks
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ */
+
+#pragma once
+#include "gs-limits.h"
+#include <inttypes.h>
+#include <xmmintrin.h>
+extern "C" {
+	#pragma warning( push )
+	#pragma warning( disable: 4201 )
+	#include <graphics/vec3.h>
+	#pragma warning( pop )
+}
+
+namespace GS {
+	struct Vertex {
+		vec3* position;
+		vec3* normal;
+		vec3* tangent;
+		uint32_t* color;
+		vec4* uv[MAXIMUM_UVW_LAYERS];
+
+		Vertex();
+		Vertex(vec3* p, vec3* n, vec3* t, uint32_t* col, vec4* uv[MAXIMUM_UVW_LAYERS]);
+		~Vertex();
+
+		private:
+		bool hasStore;
+		void* store;
+	};
+}

--- a/src/gs-vertexbuffer.cpp
+++ b/src/gs-vertexbuffer.cpp
@@ -1,0 +1,331 @@
+/*
+ * Modern effects for a modern Streamer
+ * Copyright (C) 2017 Michael Fabian Dirks
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ */
+
+#include "gs-vertexbuffer.h"
+#include "util-memory.h"
+#include <stdexcept>
+extern "C" {
+#pragma warning( push )
+#pragma warning( disable: 4201 )
+#include <obs.h>
+#pragma warning( pop )
+}
+
+GS::VertexBuffer::~VertexBuffer() {
+	if (m_positions) {
+		util::free_aligned(m_positions);
+		m_positions = nullptr;
+	}
+	if (m_normals) {
+		util::free_aligned(m_normals);
+		m_normals = nullptr;
+	}
+	if (m_tangents) {
+		util::free_aligned(m_tangents);
+		m_tangents = nullptr;
+	}
+	if (m_colors) {
+		util::free_aligned(m_colors);
+		m_colors = nullptr;
+	}
+	for (size_t n = 0; n < MAXIMUM_UVW_LAYERS; n++) {
+		if (m_uvs[n]) {
+			util::free_aligned(m_uvs[n]);
+			m_uvs[n] = nullptr;
+		}
+	}
+	if (m_layerdata) {
+		util::free_aligned(m_layerdata);
+		m_layerdata = nullptr;
+	}
+	if (m_vertexbufferdata) {
+		std::memset(m_vertexbufferdata, 0, sizeof(gs_vb_data));
+		if (!m_vertexbuffer) {
+			gs_vbdata_destroy(m_vertexbufferdata);
+			m_vertexbufferdata = nullptr;
+		}
+	}
+	if (m_vertexbuffer) {
+		obs_enter_graphics();
+		gs_vertexbuffer_destroy(m_vertexbuffer);
+		obs_leave_graphics();
+		m_vertexbuffer = nullptr;
+	}
+}
+
+GS::VertexBuffer::VertexBuffer(uint32_t maximumVertices) {
+	if (maximumVertices > MAXIMUM_VERTICES) {
+		throw std::out_of_range("maximumVertices out of range");
+	}
+
+	// Assign limits.
+	m_capacity = maximumVertices;
+	m_layers = MAXIMUM_UVW_LAYERS;
+
+	// Allocate memory for data.
+	m_vertexbufferdata = gs_vbdata_create();
+	m_vertexbufferdata->num = m_capacity;
+	m_vertexbufferdata->points = m_positions = (vec3*)util::malloc_aligned(16, sizeof(vec3) * m_capacity);
+	std::memset(m_positions, 0, sizeof(vec3) * m_capacity);
+	m_vertexbufferdata->normals = m_normals = (vec3*)util::malloc_aligned(16, sizeof(vec3) * m_capacity);
+	std::memset(m_normals, 0, sizeof(vec3) * m_capacity);
+	m_vertexbufferdata->tangents = m_tangents = (vec3*)util::malloc_aligned(16, sizeof(vec3) * m_capacity);
+	std::memset(m_tangents, 0, sizeof(vec3) * m_capacity);
+	m_vertexbufferdata->colors = m_colors = (uint32_t*)util::malloc_aligned(16, sizeof(uint32_t) * m_capacity);
+	std::memset(m_colors, 0, sizeof(uint32_t) * m_capacity);
+	m_vertexbufferdata->num_tex = m_layers;
+	m_vertexbufferdata->tvarray = m_layerdata = (gs_tvertarray*)util::malloc_aligned(16, sizeof(gs_tvertarray)* m_layers);
+	for (size_t n = 0; n < MAXIMUM_UVW_LAYERS; n++) {
+		m_layerdata[n].array = m_uvs[n] = (vec4*)util::malloc_aligned(16, sizeof(vec4) * m_capacity);
+		m_layerdata[n].width = 4;
+		std::memset(m_uvs[n], 0, sizeof(vec4) * m_capacity);
+	}
+
+	// Allocate GPU
+	obs_enter_graphics();
+	m_vertexbuffer = gs_vertexbuffer_create(m_vertexbufferdata, GS_DYNAMIC);
+	std::memset(m_vertexbufferdata, 0, sizeof(gs_vb_data));
+	m_vertexbufferdata->num = m_capacity;
+	m_vertexbufferdata->num_tex = m_layers;
+	obs_leave_graphics();
+	if (!m_vertexbuffer) {
+		throw std::runtime_error("Failed to create vertex buffer.");
+	}
+}
+
+GS::VertexBuffer::VertexBuffer(gs_vertbuffer_t* vb) {
+	gs_vb_data* vbd = gs_vertexbuffer_get_data(vb);
+	VertexBuffer((uint32_t)vbd->num);
+	this->SetUVLayers((uint32_t)vbd->num_tex);
+
+	if (vbd->points != nullptr)
+		std::memcpy(m_positions, vbd->points, vbd->num * sizeof(vec3));
+	if (vbd->normals != nullptr)
+		std::memcpy(m_normals, vbd->normals, vbd->num * sizeof(vec3));
+	if (vbd->tangents != nullptr)
+		std::memcpy(m_tangents, vbd->tangents, vbd->num * sizeof(vec3));
+	if (vbd->colors != nullptr)
+		std::memcpy(m_colors, vbd->colors, vbd->num * sizeof(uint32_t));
+	if (vbd->tvarray != nullptr) {
+		for (size_t n = 0; n < vbd->num_tex; n++) {
+			if (vbd->tvarray[n].array != nullptr && vbd->tvarray[n].width <= 4 && vbd->tvarray[n].width > 0) {
+				if (vbd->tvarray[n].width == 4) {
+					std::memcpy(m_uvs[n], vbd->tvarray[n].array, vbd->num * sizeof(vec4));
+				} else {
+					for (size_t idx = 0; idx < m_capacity; idx++) {
+						float* mem = reinterpret_cast<float*>(vbd->tvarray[n].array)
+							+ (idx * vbd->tvarray[n].width);
+						std::memset(&m_uvs[n][idx], 0, sizeof(vec4));
+						std::memcpy(&m_uvs[n][idx], mem, vbd->tvarray[n].width);
+					}
+				}
+			}
+		}
+	}
+}
+
+
+GS::VertexBuffer::VertexBuffer(VertexBuffer const& other) : VertexBuffer(other.m_capacity) {
+	// Copy Constructor
+	std::memcpy(m_positions, other.m_positions, m_capacity * sizeof(vec3));
+	std::memcpy(m_normals, other.m_normals, m_capacity * sizeof(vec3));
+	std::memcpy(m_tangents, other.m_tangents, m_capacity * sizeof(vec3));
+	std::memcpy(m_colors, other.m_colors, m_capacity * sizeof(vec3));
+	for (size_t n = 0; n < MAXIMUM_UVW_LAYERS; n++) {
+		std::memcpy(m_uvs[n], other.m_uvs[n], m_capacity * sizeof(vec3));
+	}
+}
+
+GS::VertexBuffer::VertexBuffer(VertexBuffer const&& other) {
+	// Move Constructor
+	m_capacity = other.m_capacity;
+	m_size = other.m_size;
+	m_layers = other.m_layers;
+	m_positions = other.m_positions;
+	m_normals = other.m_normals;
+	m_tangents = other.m_tangents;
+	for (size_t n = 0; n < MAXIMUM_UVW_LAYERS; n++) {
+		m_uvs[n] = other.m_uvs[n];
+	}
+	m_vertexbufferdata = other.m_vertexbufferdata;
+	m_vertexbuffer = other.m_vertexbuffer;
+	m_layerdata = other.m_layerdata;
+}
+
+void GS::VertexBuffer::operator=(VertexBuffer const&& other) {
+	// Move Assignment
+	/// First self-destruct (semi-destruct itself).
+	if (m_positions) {
+		util::free_aligned(m_positions);
+		m_positions = nullptr;
+	}
+	if (m_normals) {
+		util::free_aligned(m_normals);
+		m_normals = nullptr;
+	}
+	if (m_tangents) {
+		util::free_aligned(m_tangents);
+		m_tangents = nullptr;
+	}
+	if (m_colors) {
+		util::free_aligned(m_colors);
+		m_colors = nullptr;
+	}
+	for (size_t n = 0; n < MAXIMUM_UVW_LAYERS; n++) {
+		if (m_uvs[n]) {
+			util::free_aligned(m_uvs[n]);
+			m_uvs[n] = nullptr;
+		}
+	}
+	if (m_layerdata) {
+		util::free_aligned(m_layerdata);
+		m_layerdata = nullptr;
+	}
+	if (m_vertexbufferdata) {
+		std::memset(m_vertexbufferdata, 0, sizeof(gs_vb_data));
+		if (!m_vertexbuffer) {
+			gs_vbdata_destroy(m_vertexbufferdata);
+			m_vertexbufferdata = nullptr;
+		}
+	}
+	if (m_vertexbuffer) {
+		obs_enter_graphics();
+		gs_vertexbuffer_destroy(m_vertexbuffer);
+		obs_leave_graphics();
+		m_vertexbuffer = nullptr;
+	}
+
+	/// Then assign new values.
+	m_capacity = other.m_capacity;
+	m_size = other.m_size;
+	m_layers = other.m_layers;
+	m_positions = other.m_positions;
+	m_normals = other.m_normals;
+	m_tangents = other.m_tangents;
+	for (size_t n = 0; n < MAXIMUM_UVW_LAYERS; n++) {
+		m_uvs[n] = other.m_uvs[n];
+	}
+	m_vertexbufferdata = other.m_vertexbufferdata;
+	m_vertexbuffer = other.m_vertexbuffer;
+	m_layerdata = other.m_layerdata;
+}
+
+void GS::VertexBuffer::Resize(uint32_t new_size) {
+	if (new_size > m_capacity) {
+		throw std::out_of_range("new_size out of range");
+	}
+	m_size = new_size;
+}
+
+uint32_t GS::VertexBuffer::Size() {
+	return m_size;
+}
+
+bool GS::VertexBuffer::Empty() {
+	return m_size == 0;
+}
+
+const GS::Vertex GS::VertexBuffer::At(uint32_t idx) {
+	if ((idx < 0) || (idx >= m_size)) {
+		throw std::out_of_range("idx out of range");
+	}
+
+	GS::Vertex vtx(&m_positions[idx], &m_normals[idx], &m_tangents[idx], &m_colors[idx], nullptr);
+	for (size_t n = 0; n < MAXIMUM_UVW_LAYERS; n++) {
+		vtx.uv[n] = &m_uvs[n][idx];
+	}
+	return vtx;
+}
+
+const GS::Vertex GS::VertexBuffer::operator[](uint32_t const pos) {
+	return At(pos);
+}
+
+void GS::VertexBuffer::SetUVLayers(uint32_t layers) {
+	m_layers = layers;
+}
+
+uint32_t GS::VertexBuffer::GetUVLayers() {
+	return m_layers;
+}
+
+vec3* GS::VertexBuffer::GetPositions() {
+	return m_positions;
+}
+
+vec3* GS::VertexBuffer::GetNormals() {
+	return m_normals;
+}
+
+vec3* GS::VertexBuffer::GetTangents() {
+	return m_tangents;
+}
+
+uint32_t* GS::VertexBuffer::GetColors() {
+	return m_colors;
+}
+
+vec4* GS::VertexBuffer::GetUVLayer(size_t idx) {
+	if ((idx < 0) || (idx >= m_layers)) {
+		throw std::out_of_range("idx out of range");
+	}
+	return m_uvs[idx];
+}
+
+gs_vertbuffer_t* GS::VertexBuffer::Update(bool refreshGPU) {
+	if (!refreshGPU)
+		return m_vertexbuffer;
+
+	if (m_size > m_capacity)
+		throw std::out_of_range("size is larger than capacity");
+
+	// Update VertexBuffer data.
+	m_vertexbufferdata = gs_vertexbuffer_get_data(m_vertexbuffer);
+	std::memset(m_vertexbufferdata, 0, sizeof(gs_vb_data));
+	m_vertexbufferdata->num = m_capacity;
+	m_vertexbufferdata->points = m_positions;
+	m_vertexbufferdata->normals = m_normals;
+	m_vertexbufferdata->tangents = m_tangents;
+	m_vertexbufferdata->colors = m_colors;
+	m_vertexbufferdata->num_tex = m_layers;
+	m_vertexbufferdata->tvarray = m_layerdata;
+	for (size_t n = 0; n < MAXIMUM_UVW_LAYERS; n++) {
+		m_layerdata[n].array = m_uvs[n];
+		m_layerdata[n].width = 4;
+	}
+
+	// Update GPU
+	obs_enter_graphics();
+	gs_vertexbuffer_flush(m_vertexbuffer);
+	obs_leave_graphics();
+
+	// WORKAROUND: OBS Studio 20.x and below incorrectly deletes data that it doesn't own.
+	std::memset(m_vertexbufferdata, 0, sizeof(gs_vb_data));
+	m_vertexbufferdata->num = m_capacity;
+	m_vertexbufferdata->num_tex = m_layers;
+	for (uint32_t n = 0; n < m_layers; n++) {
+		m_layerdata[n].width = 4;
+	}
+
+	return m_vertexbuffer;
+}
+
+gs_vertbuffer_t* GS::VertexBuffer::Update() {
+	return Update(true);
+}

--- a/src/gs-vertexbuffer.h
+++ b/src/gs-vertexbuffer.h
@@ -1,0 +1,179 @@
+/*
+ * Modern effects for a modern Streamer
+ * Copyright (C) 2017 Michael Fabian Dirks
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ */
+
+#pragma once
+#include "gs-limits.h"
+#include "gs-vertex.h"
+#include "util-memory.h"
+#include <inttypes.h>
+extern "C" {
+#pragma warning( push )
+#pragma warning( disable: 4201 )
+#include <graphics/graphics.h>
+#pragma warning( pop )
+}
+
+namespace GS {
+	class VertexBuffer {
+		public:
+	#pragma region Constructor & Destructor
+		virtual ~VertexBuffer();
+
+		/*!
+		* \brief Create a Vertex Buffer with a specific number of Vertices.
+		*
+		* \param maximumVertices Maximum amount of vertices to store.
+		*/
+		VertexBuffer(uint32_t maximumVertices);
+
+		/*!
+		* \brief Create a Vertex Buffer with the maximum number of Vertices.
+		*
+		* \param maximumVertices Maximum amount of vertices to store.
+		*/
+		VertexBuffer() : VertexBuffer(MAXIMUM_VERTICES) {};
+
+		/*!
+		* \brief Create a copy of a Vertex Buffer
+		* Full Description below
+		*
+		* \param other The Vertex Buffer to copy
+		*/
+		VertexBuffer(gs_vertbuffer_t* other);
+
+	#pragma endregion Constructor & Destructor
+
+	#pragma region Copy/Move Constructors
+		// Copy Constructor & Assignments
+
+		/*!
+		* \brief Copy Constructor
+		* 
+		*
+		* \param other 
+		*/
+		VertexBuffer(VertexBuffer const& other);
+
+		/*!
+		* \brief Copy Assignment
+		* Unsafe operation and as such marked as deleted.
+		*
+		* \param other
+		*/
+		void operator=(VertexBuffer const& other) = delete;
+
+		// Move Constructor & Assignments
+
+		/*!
+		* \brief Move Constructor
+		*
+		*
+		* \param other
+		*/
+		VertexBuffer(VertexBuffer const&& other);
+
+		/*!
+		* \brief Move Assignment
+		*
+		*
+		* \param other
+		*/
+		void operator=(VertexBuffer const&& other);
+	#pragma endregion Copy/Move Constructors
+		
+
+
+		void Resize(uint32_t new_size);
+
+		uint32_t Size();
+
+		bool Empty();
+
+		const GS::Vertex At(uint32_t idx);
+
+		const GS::Vertex operator[](uint32_t const pos);
+
+		void SetUVLayers(uint32_t layers);
+
+		uint32_t GetUVLayers();
+
+		/*!
+		* \brief Directly access the positions buffer
+		* Returns the internal memory that is assigned to hold all vertex positions.
+		*
+		* \return A <vec3*> that points at the first vertex's position.
+		*/
+		vec3* GetPositions();
+
+		/*!
+		* \brief Directly access the normals buffer
+		* Returns the internal memory that is assigned to hold all vertex normals.
+		*
+		* \return A <vec3*> that points at the first vertex's normal.
+		*/
+		vec3* GetNormals();
+
+		/*!
+		* \brief Directly access the tangents buffer
+		* Returns the internal memory that is assigned to hold all vertex tangents.
+		*
+		* \return A <vec3*> that points at the first vertex's tangent.
+		*/
+		vec3* GetTangents();
+
+		/*!
+		* \brief Directly access the colors buffer
+		* Returns the internal memory that is assigned to hold all vertex colors.
+		*
+		* \return A <uint32_t*> that points at the first vertex's color.
+		*/
+		uint32_t* GetColors();
+
+		/*!
+		* \brief Directly access the uv buffer
+		* Returns the internal memory that is assigned to hold all vertex uvs.
+		*
+		* \return A <vec4*> that points at the first vertex's uv.
+		*/
+		vec4* GetUVLayer(size_t idx);
+
+	#pragma region Update / Grab GS object
+		gs_vertbuffer_t* Update();
+
+		gs_vertbuffer_t* Update(bool refreshGPU);
+	#pragma endregion Update / Grab GS object
+
+		private:
+		uint32_t m_size;
+		uint32_t m_capacity;
+		uint32_t m_layers;
+
+		// Memory Storage
+		vec3 *m_positions;
+		vec3 *m_normals;
+		vec3 *m_tangents;
+		uint32_t *m_colors;
+		vec4 *m_uvs[MAXIMUM_UVW_LAYERS];
+
+		// OBS GS Data
+		gs_vb_data* m_vertexbufferdata;
+		gs_vertbuffer_t* m_vertexbuffer;
+		gs_tvertarray* m_layerdata;
+	};
+}

--- a/src/nodeobs_display.h
+++ b/src/nodeobs_display.h
@@ -5,6 +5,7 @@
 #include <system_error>
 #include <algorithm>
 #include <vector>
+#include "gs-vertexbuffer.h"
 
 #if defined(_WIN32)
 #ifdef NOWINOFFSETS
@@ -21,34 +22,6 @@ EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 #endif
 
 namespace OBS {
-	struct VertexHelper {
-		VertexHelper();
-
-		vec3 pos, normal, tangent;
-		uint32_t color;
-		vec2 uv0, uv1;
-	};
-
-	class VertexBufferHelper {
-		private:
-		gs_vertbuffer_t* vb;
-		gs_vb_data* vbdata;
-		std::vector<VertexHelper> vertices;
-		std::vector<gs_tvertarray> vbuvdata;
-		std::vector<vec3> t_vertices, t_normals, t_tangents;
-		std::vector<uint32_t> t_colors;
-		std::vector<vec2> t_uv0, t_uv1;
-
-		public:
-		VertexBufferHelper(size_t initialSize = 65535);
-		virtual ~VertexBufferHelper();
-
-		void clear();
-		VertexHelper* add();
-		gs_vertbuffer_t* update();
-		size_t size();
-	};
-
 	class Display {
 		#pragma region Constructors & Finalizer
 		private:
@@ -105,7 +78,7 @@ namespace OBS {
 			*m_textEffect;
 		gs_texture_t *m_textTexture;
 
-		VertexBufferHelper
+		GS::VertexBuffer
 			*m_lines,
 			*m_triangles,
 			*m_textVertices;

--- a/src/util-memory.cpp
+++ b/src/util-memory.cpp
@@ -1,0 +1,43 @@
+/*
+* Modern effects for a modern Streamer
+* Copyright (C) 2017 Michael Fabian Dirks
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+*/
+
+#include "util-memory.h"
+#include <cstdlib>
+
+void* util::malloc_aligned(size_t align, size_t size) {
+	// Ensure that we have space for the pointer and the data.
+	size_t asize = aligned_offset(align, size + sizeof(void*));
+
+	// Allocate memory and store integer representation of pointer.
+	void* ptr = malloc(asize);
+
+	// Calculate actual aligned position
+	intptr_t ptr_off = aligned_offset(align, reinterpret_cast<size_t>(ptr)+sizeof(void*));
+
+	// Store actual pointer at ptr_off - sizeof(void*).
+	*reinterpret_cast<intptr_t*>(ptr_off - sizeof(void*)) = reinterpret_cast<intptr_t>(ptr);
+
+	// Return aligned pointer
+	return reinterpret_cast<void*>(ptr_off);
+}
+
+void util::free_aligned(void* mem) {
+	void* ptr = reinterpret_cast<void*>(*reinterpret_cast<intptr_t*>(static_cast<char*>(mem)-sizeof(void*)));
+	free(ptr);
+}

--- a/src/util-memory.h
+++ b/src/util-memory.h
@@ -1,0 +1,98 @@
+/*
+ * Modern effects for a modern Streamer
+ * Copyright (C) 2017 Michael Fabian Dirks
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ */
+
+#pragma once
+#include <stdlib.h>
+#include <malloc.h>
+
+namespace util {
+	inline size_t aligned_offset(size_t align, size_t pos) {
+		return ((pos / align) + 1) * align;
+	}
+	void* malloc_aligned(size_t align, size_t size);
+	void free_aligned(void* mem);
+
+	template <typename T, size_t N = 16>
+	class AlignmentAllocator {
+		public:
+		typedef T value_type;
+		typedef size_t size_type;
+		typedef std::ptrdiff_t difference_type;
+
+		typedef T * pointer;
+		typedef const T * const_pointer;
+
+		typedef T & reference;
+		typedef const T & const_reference;
+
+		public:
+		inline AlignmentAllocator() throw () {}
+
+		template <typename T2>
+		inline AlignmentAllocator(const AlignmentAllocator<T2, N> &) throw () {}
+
+		inline ~AlignmentAllocator() throw () {}
+
+		inline pointer adress(reference r) {
+			return &r;
+		}
+
+		inline const_pointer adress(const_reference r) const {
+			return &r;
+		}
+
+		inline pointer allocate(size_type n) {
+			return (pointer)malloc_aligned(n*sizeof(value_type), N);
+		}
+
+		inline void deallocate(pointer p, size_type) {
+			free_aligned(p);
+		}
+
+		inline void construct(pointer p, const value_type & wert) {
+			new (p)value_type(wert);
+		}
+
+		inline void destroy(pointer p) {
+			p->~value_type();
+			p;
+		}
+
+		inline size_type max_size() const throw () {
+			return size_type(-1) / sizeof(value_type);
+		}
+
+		template <typename T2>
+		struct rebind {
+			typedef AlignmentAllocator<T2, N> other;
+		};
+
+		bool operator!=(const AlignmentAllocator<T, N>& other) const {
+			return !(*this == other);
+		}
+
+		// Returns true if and only if storage allocated from *this
+		// can be deallocated from other, and vice versa.
+		// Always returns true for stateless allocators.
+		bool operator==(const AlignmentAllocator<T, N>& other) const {
+			return true;
+		}
+	};
+};
+


### PR DESCRIPTION
This crash happens every 1 in 100000 times in obs-stream-effects 64-bit, which has the same GS::VertexBuffer wrapper as node-obs::Display and Face Masks. The crash happens due to unlucky placement of the buffers, which need to be 16-byte aligned, otherwise we write into memory that we shouldn't have written to. This results in funky crashes down the road which make absolutely no sense at all with a mdmp or a simple stack trace, since the cause of the crash happened earlier.

Affects pretty much all areas, as the Display was actively writing into memory of other areas. This might explain some exotic behavior we have seen, such as crashes inside the Chromium runtime or electron crashes.