### PR TITLE
Reduce the large amount of redundancy in the client

### DIFF
--- a/obs-studio-client/source/scene.cpp
+++ b/obs-studio-client/source/scene.cpp
@@ -68,234 +68,60 @@ void osn::Scene::Register(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
 Nan::NAN_METHOD_RETURN_TYPE osn::Scene::Create(Nan::NAN_METHOD_ARGS_TYPE info) {
 	std::string name;
 
-	// Parameters: <string> Name
 	ASSERT_INFO_LENGTH(info, 1);
 	ASSERT_GET_VALUE(info[0], name);
 
-	// Perform the call
-	struct ThreadData {
-		std::condition_variable cv;
-		std::mutex mtx;
+	auto conn = Controller::GetInstance().GetConnection();
 
-		bool called = false;
-		ErrorCode error_code = ErrorCode::Ok;
-		std::string error_string = "";
+	std::vector<ipc::value> response = conn->call_synchronous_helper(
+		"Scene", "Create",
+		std::vector<ipc::value>{ ipc::value(name) }
+	);
 
-		// Results
-		uint64_t sourceId;
-	} rtd;
+	ASSERT_RESPONSE_VALID(response);
 
-	auto fnc = [](const void* data, const std::vector<ipc::value>& rval) {
-		ThreadData* rtd = const_cast<ThreadData*>(static_cast<const ThreadData*>(data));
-
-		if ((rval.size() == 1) && (rval[0].type == ipc::type::Null)) {
-			rtd->error_code = ErrorCode::Error;
-			rtd->error_string = rval[0].value_str;
-			rtd->called = true;
-			rtd->cv.notify_all();
-			return;
-		}
-
-		rtd->error_code = (ErrorCode)rval[0].value_union.ui64;
-		if (rtd->error_code != ErrorCode::Ok) {
-			rtd->error_string = rval[1].value_str;
-			rtd->called = true;
-			rtd->cv.notify_all();
-			return;
-		}
-
-		rtd->sourceId = rval[1].value_union.ui64;
-
-		rtd->called = true;
-		rtd->cv.notify_all();
-	};
-
-	bool suc = Controller::GetInstance().GetConnection()->call("Scene", "Create",
-		std::vector<ipc::value>{ ipc::value(name) }, fnc, &rtd);
-	if (!suc) {
-		info.GetIsolate()->ThrowException(
-			v8::Exception::Error(
-				Nan::New<v8::String>(
-					"Failed to make IPC call, verify IPC status."
-					).ToLocalChecked()
-			));
-		return;
-	}
-
-	std::unique_lock<std::mutex> ulock(rtd.mtx);
-	rtd.cv.wait(ulock, [&rtd]() { return rtd.called; });
-
-	if (rtd.error_code != ErrorCode::Ok) {
-		if (rtd.error_code == ErrorCode::InvalidReference) {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::ReferenceError(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		} else {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::Error(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		}
-		return;
-	}
+	uint64_t sourceId = response[1].value_union.ui64;
 
 	// Create new Filter
-	osn::Scene* obj = new osn::Scene(rtd.sourceId);
+	osn::Scene* obj = new osn::Scene(sourceId);
 	info.GetReturnValue().Set(osn::Scene::Store(obj));
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::Scene::CreatePrivate(Nan::NAN_METHOD_ARGS_TYPE info) {
 	std::string name;
 
-	// Parameters: <string> Name
 	ASSERT_INFO_LENGTH(info, 1);
 	ASSERT_GET_VALUE(info[0], name);
 
-	// Perform the call
-	struct ThreadData {
-		std::condition_variable cv;
-		std::mutex mtx;
+	auto conn = Controller::GetInstance().GetConnection();
 
-		bool called = false;
-		ErrorCode error_code = ErrorCode::Ok;
-		std::string error_string = "";
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "CreatePrivate",
+		std::vector<ipc::value>{ ipc::value(name) });
 
-		// Results
-		uint64_t sourceId;
-	} rtd;
+	ASSERT_RESPONSE_VALID(response);
 
-	auto fnc = [](const void* data, const std::vector<ipc::value>& rval) {
-		ThreadData* rtd = const_cast<ThreadData*>(static_cast<const ThreadData*>(data));
+	uint64_t sourceId = response[1].value_union.ui64;
 
-		if ((rval.size() == 1) && (rval[0].type == ipc::type::Null)) {
-			rtd->error_code = ErrorCode::Error;
-			rtd->error_string = rval[0].value_str;
-			rtd->called = true;
-			rtd->cv.notify_all();
-			return;
-		}
-
-		rtd->error_code = (ErrorCode)rval[0].value_union.ui64;
-		if (rtd->error_code != ErrorCode::Ok) {
-			rtd->error_string = rval[1].value_str;
-			rtd->called = true;
-			rtd->cv.notify_all();
-			return;
-		}
-
-		rtd->sourceId = rval[1].value_union.ui64;
-
-		rtd->called = true;
-		rtd->cv.notify_all();
-	};
-
-	bool suc = Controller::GetInstance().GetConnection()->call("Scene", "CreatePrivate",
-		std::vector<ipc::value>{ ipc::value(name) }, fnc, &rtd);
-	if (!suc) {
-		info.GetIsolate()->ThrowException(
-			v8::Exception::Error(
-				Nan::New<v8::String>(
-					"Failed to make IPC call, verify IPC status."
-					).ToLocalChecked()
-			));
-		return;
-	}
-
-	std::unique_lock<std::mutex> ulock(rtd.mtx);
-	rtd.cv.wait(ulock, [&rtd]() { return rtd.called; });
-
-	if (rtd.error_code != ErrorCode::Ok) {
-		if (rtd.error_code == ErrorCode::InvalidReference) {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::ReferenceError(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		} else {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::Error(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		}
-		return;
-	}
-
-	// Create new Filter
-	osn::Scene* obj = new osn::Scene(rtd.sourceId);
+	osn::Scene* obj = new osn::Scene(sourceId);
 	info.GetReturnValue().Set(osn::Scene::Store(obj));
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::Scene::FromName(Nan::NAN_METHOD_ARGS_TYPE info) {
 	std::string name;
 
-	// Parameters: <string> Name
 	ASSERT_INFO_LENGTH(info, 1);
 	ASSERT_GET_VALUE(info[0], name);
 
-	// Perform the call
-	struct ThreadData {
-		std::condition_variable cv;
-		std::mutex mtx;
+	auto conn = Controller::GetInstance().GetConnection();
 
-		bool called = false;
-		ErrorCode error_code = ErrorCode::Ok;
-		std::string error_string = "";
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "FromName",
+		{ ipc::value(name) });
 
-		// Results
-		uint64_t sourceId;
-	} rtd;
+	ASSERT_RESPONSE_VALID(response);
 
-	auto fnc = [](const void* data, const std::vector<ipc::value>& rval) {
-		ThreadData* rtd = const_cast<ThreadData*>(static_cast<const ThreadData*>(data));
+	uint64_t sourceId = response[1].value_union.ui64;
 
-		if ((rval.size() == 1) && (rval[0].type == ipc::type::Null)) {
-			rtd->error_code = ErrorCode::Error;
-			rtd->error_string = rval[0].value_str;
-			rtd->called = true;
-			rtd->cv.notify_all();
-			return;
-		}
-
-		rtd->error_code = (ErrorCode)rval[0].value_union.ui64;
-		if (rtd->error_code != ErrorCode::Ok) {
-			rtd->error_string = rval[1].value_str;
-			rtd->called = true;
-			rtd->cv.notify_all();
-			return;
-		}
-
-		rtd->sourceId = rval[1].value_union.ui64;
-
-		rtd->called = true;
-		rtd->cv.notify_all();
-	};
-
-	bool suc = Controller::GetInstance().GetConnection()->call("Scene", "FromName",
-	{ ipc::value(name) }, fnc, &rtd);
-	if (!suc) {
-		info.GetIsolate()->ThrowException(
-			v8::Exception::Error(
-				Nan::New<v8::String>(
-					"Failed to make IPC call, verify IPC status."
-					).ToLocalChecked()
-			));
-		return;
-	}
-
-	std::unique_lock<std::mutex> ulock(rtd.mtx);
-	rtd.cv.wait(ulock, [&rtd]() { return rtd.called; });
-
-	if (rtd.error_code != ErrorCode::Ok) {
-		if (rtd.error_code == ErrorCode::InvalidReference) {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::ReferenceError(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		} else {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::Error(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		}
-		return;
-	}
-
-	// Create new Filter
-	osn::Scene* obj = new osn::Scene(rtd.sourceId);
+	osn::Scene* obj = new osn::Scene(sourceId);
 	info.GetReturnValue().Set(osn::Scene::Store(obj));
 }
 
@@ -305,64 +131,12 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::Release(Nan::NAN_METHOD_ARGS_TYPE info) 
 		return;
 	}
 
-	struct ThreadData {
-		std::condition_variable cv;
-		std::mutex mtx;
-		bool called = false;
-		ErrorCode error_code = ErrorCode::Ok;
-		std::string error_string = "";
-	} rtd;
+	auto conn = Controller::GetInstance().GetConnection();
 
-	auto fnc = [](const void* data, const std::vector<ipc::value>& rval) {
-		ThreadData* rtd = const_cast<ThreadData*>(static_cast<const ThreadData*>(data));
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "Release",
+		std::vector<ipc::value>{ipc::value(source->sourceId)});
 
-		if ((rval.size() == 1) && (rval[0].type == ipc::type::Null)) {
-			rtd->error_code = ErrorCode::Error;
-			rtd->error_string = rval[0].value_str;
-			rtd->called = true;
-			rtd->cv.notify_all();
-			return;
-		}
-
-		rtd->error_code = (ErrorCode)rval[0].value_union.ui64;
-		if (rtd->error_code != ErrorCode::Ok) {
-			rtd->error_string = rval[1].value_str;
-		}
-
-		rtd->called = true;
-		rtd->cv.notify_all();
-	};
-
-	bool suc = Controller::GetInstance().GetConnection()->call("Scene", "Release",
-		std::vector<ipc::value>{ipc::value(source->sourceId)}, fnc, &rtd);
-	if (!suc) {
-		info.GetIsolate()->ThrowException(
-			v8::Exception::Error(
-				Nan::New<v8::String>(
-					"Failed to make IPC call, verify IPC status."
-					).ToLocalChecked()
-			));
-		return;
-	}
-
-	std::unique_lock<std::mutex> ulock(rtd.mtx);
-	rtd.cv.wait(ulock, [&rtd]() { return rtd.called; });
-
-	if (rtd.error_code != ErrorCode::Ok) {
-		if (rtd.error_code == ErrorCode::InvalidReference) {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::ReferenceError(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		} else {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::Error(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		}
-		return;
-	}
-
-	source->sourceId = UINT64_MAX;
-	return;
+	ASSERT_RESPONSE_VALID(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::Scene::Remove(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -371,64 +145,12 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::Remove(Nan::NAN_METHOD_ARGS_TYPE info) {
 		return;
 	}
 
-	struct ThreadData {
-		std::condition_variable cv;
-		std::mutex mtx;
-		bool called = false;
-		ErrorCode error_code = ErrorCode::Ok;
-		std::string error_string = "";
-	} rtd;
+	auto conn = Controller::GetInstance().GetConnection();
 
-	auto fnc = [](const void* data, const std::vector<ipc::value>& rval) {
-		ThreadData* rtd = const_cast<ThreadData*>(static_cast<const ThreadData*>(data));
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "Remove",
+		std::vector<ipc::value>{ipc::value(source->sourceId)});
 
-		if ((rval.size() == 1) && (rval[0].type == ipc::type::Null)) {
-			rtd->error_code = ErrorCode::Error;
-			rtd->error_string = rval[0].value_str;
-			rtd->called = true;
-			rtd->cv.notify_all();
-			return;
-		}
-
-		rtd->error_code = (ErrorCode)rval[0].value_union.ui64;
-		if (rtd->error_code != ErrorCode::Ok) {
-			rtd->error_string = rval[1].value_str;
-		}
-
-		rtd->called = true;
-		rtd->cv.notify_all();
-	};
-
-	bool suc = Controller::GetInstance().GetConnection()->call("Scene", "Remove",
-		std::vector<ipc::value>{ipc::value(source->sourceId)}, fnc, &rtd);
-	if (!suc) {
-		info.GetIsolate()->ThrowException(
-			v8::Exception::Error(
-				Nan::New<v8::String>(
-					"Failed to make IPC call, verify IPC status."
-					).ToLocalChecked()
-			));
-		return;
-	}
-
-	std::unique_lock<std::mutex> ulock(rtd.mtx);
-	rtd.cv.wait(ulock, [&rtd]() { return rtd.called; });
-
-	if (rtd.error_code != ErrorCode::Ok) {
-		if (rtd.error_code == ErrorCode::InvalidReference) {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::ReferenceError(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		} else {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::Error(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		}
-		return;
-	}
-
-	source->sourceId = UINT64_MAX;
-	return;
+	ASSERT_RESPONSE_VALID(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::Scene::AsSource(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -438,7 +160,6 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::AsSource(Nan::NAN_METHOD_ARGS_TYPE info)
 		return;
 	}
 
-	// Create new Input
 	osn::Input* obj = new osn::Input(source->sourceId);
 	info.GetReturnValue().Set(osn::Input::Store(obj));
 }
@@ -456,67 +177,16 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::Duplicate(Nan::NAN_METHOD_ARGS_TYPE info
 	ASSERT_GET_VALUE(info[0], name);
 	ASSERT_GET_VALUE(info[1], duplicate_type);
 
-	struct ThreadData {
-		std::condition_variable cv;
-		std::mutex mtx;
-		bool called = false;
-		ErrorCode error_code = ErrorCode::Ok;
-		std::string error_string = "";
+	auto conn = Controller::GetInstance().GetConnection();
 
-		uint64_t source_id;
-	} rtd;
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "Duplicate",
+		std::vector<ipc::value>{ipc::value(source->sourceId), ipc::value(name), ipc::value(duplicate_type)});
 
-	auto fnc = [](const void* data, const std::vector<ipc::value>& rval) {
-		ThreadData* rtd = const_cast<ThreadData*>(static_cast<const ThreadData*>(data));
+	ASSERT_RESPONSE_VALID(response);
 
-		if ((rval.size() == 1) && (rval[0].type == ipc::type::Null)) {
-			rtd->error_code = ErrorCode::Error;
-			rtd->error_string = rval[0].value_str;
-			rtd->called = true;
-			rtd->cv.notify_all();
-			return;
-		}
+	uint64_t sourceId = response[1].value_union.ui64;
 
-		rtd->error_code = (ErrorCode)rval[0].value_union.ui64;
-		if (rtd->error_code != ErrorCode::Ok) {
-			rtd->error_string = rval[1].value_str;
-		}
-
-		rtd->source_id = rval[1].value_union.ui64;
-		rtd->called = true;
-		rtd->cv.notify_all();
-	};
-
-	bool suc = Controller::GetInstance().GetConnection()->call("Scene", "Duplicate",
-		std::vector<ipc::value>{ipc::value(source->sourceId), ipc::value(name), ipc::value(duplicate_type)}, fnc, &rtd);
-	if (!suc) {
-		info.GetIsolate()->ThrowException(
-			v8::Exception::Error(
-				Nan::New<v8::String>(
-					"Failed to make IPC call, verify IPC status."
-					).ToLocalChecked()
-			));
-		return;
-	}
-
-	std::unique_lock<std::mutex> ulock(rtd.mtx);
-	rtd.cv.wait(ulock, [&rtd]() { return rtd.called; });
-
-	if (rtd.error_code != ErrorCode::Ok) {
-		if (rtd.error_code == ErrorCode::InvalidReference) {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::ReferenceError(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		} else {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::Error(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		}
-		return;
-	}
-
-	// Create new Scene
-	osn::Scene* obj = new osn::Scene(rtd.source_id);
+	osn::Scene* obj = new osn::Scene(sourceId);
 	info.GetReturnValue().Set(osn::Scene::Store(obj));
 }
 
@@ -532,67 +202,17 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::AddSource(Nan::NAN_METHOD_ARGS_TYPE info
 		return;
 	}
 
-	struct ThreadData {
-		std::condition_variable cv;
-		std::mutex mtx;
-		bool called = false;
-		ErrorCode error_code = ErrorCode::Ok;
-		std::string error_string = "";
+	auto conn = Controller::GetInstance().GetConnection();
 
-		uint64_t id;
-	} rtd;
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "AddSource",
+		std::vector<ipc::value>{ipc::value(scene->sourceId), ipc::value(input->sourceId)});
 
-	auto fnc = [](const void* data, const std::vector<ipc::value>& rval) {
-		ThreadData* rtd = const_cast<ThreadData*>(static_cast<const ThreadData*>(data));
+	ASSERT_RESPONSE_VALID(response);
 
-		if ((rval.size() == 1) && (rval[0].type == ipc::type::Null)) {
-			rtd->error_code = ErrorCode::Error;
-			rtd->error_string = rval[0].value_str;
-			rtd->called = true;
-			rtd->cv.notify_all();
-			return;
-		}
-
-		rtd->error_code = (ErrorCode)rval[0].value_union.ui64;
-		if (rtd->error_code != ErrorCode::Ok) {
-			rtd->error_string = rval[1].value_str;
-		}
-
-		rtd->id = rval[1].value_union.ui64;
-		rtd->called = true;
-		rtd->cv.notify_all();
-	};
-
-	bool suc = Controller::GetInstance().GetConnection()->call("Scene", "AddSource",
-		std::vector<ipc::value>{ipc::value(scene->sourceId), ipc::value(input->sourceId)}, fnc, &rtd);
-	if (!suc) {
-		info.GetIsolate()->ThrowException(
-			v8::Exception::Error(
-				Nan::New<v8::String>(
-					"Failed to make IPC call, verify IPC status."
-					).ToLocalChecked()
-			));
-		return;
-	}
-
-	std::unique_lock<std::mutex> ulock(rtd.mtx);
-	rtd.cv.wait(ulock, [&rtd]() { return rtd.called; });
-
-	if (rtd.error_code != ErrorCode::Ok) {
-		if (rtd.error_code == ErrorCode::InvalidReference) {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::ReferenceError(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		} else {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::Error(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		}
-		return;
-	}
+	uint64_t id = response[1].value_union.ui64;
 
 	// Create new SceneItem
-	osn::SceneItem* obj = new osn::SceneItem(rtd.id);
+	osn::SceneItem* obj = new osn::SceneItem(id);
 	info.GetReturnValue().Set(osn::SceneItem::Store(obj));
 }
 
@@ -618,68 +238,17 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::FindItem(Nan::NAN_METHOD_ARGS_TYPE info)
 		return;
 	}
 
-	struct ThreadData {
-		std::condition_variable cv;
-		std::mutex mtx;
-		bool called = false;
-		ErrorCode error_code = ErrorCode::Ok;
-		std::string error_string = "";
+	auto conn = Controller::GetInstance().GetConnection();
 
-		uint64_t id;
-	} rtd;
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "FindItem",
+		std::vector<ipc::value>{ipc::value(scene->sourceId),
+		(haveName ? ipc::value(name) : ipc::value(position))});
 
-	auto fnc = [](const void* data, const std::vector<ipc::value>& rval) {
-		ThreadData* rtd = const_cast<ThreadData*>(static_cast<const ThreadData*>(data));
+	ASSERT_RESPONSE_VALID(response);
 
-		if ((rval.size() == 1) && (rval[0].type == ipc::type::Null)) {
-			rtd->error_code = ErrorCode::Error;
-			rtd->error_string = rval[0].value_str;
-			rtd->called = true;
-			rtd->cv.notify_all();
-			return;
-		}
+	uint64_t id = response[1].value_union.ui64;
 
-		rtd->error_code = (ErrorCode)rval[0].value_union.ui64;
-		if (rtd->error_code != ErrorCode::Ok) {
-			rtd->error_string = rval[1].value_str;
-		}
-
-		rtd->id = rval[1].value_union.ui64;
-		rtd->called = true;
-		rtd->cv.notify_all();
-	};
-
-	bool suc = Controller::GetInstance().GetConnection()->call("Scene", "FindItem",
-		std::vector<ipc::value>{ipc::value(scene->sourceId), 
-		(haveName ? ipc::value(name) : ipc::value(position))}, fnc, &rtd);
-	if (!suc) {
-		info.GetIsolate()->ThrowException(
-			v8::Exception::Error(
-				Nan::New<v8::String>(
-					"Failed to make IPC call, verify IPC status."
-					).ToLocalChecked()
-			));
-		return;
-	}
-
-	std::unique_lock<std::mutex> ulock(rtd.mtx);
-	rtd.cv.wait(ulock, [&rtd]() { return rtd.called; });
-
-	if (rtd.error_code != ErrorCode::Ok) {
-		if (rtd.error_code == ErrorCode::InvalidReference) {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::ReferenceError(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		} else {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::Error(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		}
-		return;
-	}
-
-	// Create new SceneItem
-	osn::SceneItem* obj = new osn::SceneItem(rtd.id);
+	osn::SceneItem* obj = new osn::SceneItem(id);
 	info.GetReturnValue().Set(osn::SceneItem::Store(obj));
 }
 
@@ -694,61 +263,12 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::MoveItem(Nan::NAN_METHOD_ARGS_TYPE info)
 	ASSERT_GET_VALUE(info[0], from);
 	ASSERT_GET_VALUE(info[1], to);
 
-	struct ThreadData {
-		std::condition_variable cv;
-		std::mutex mtx;
-		bool called = false;
-		ErrorCode error_code = ErrorCode::Ok;
-		std::string error_string = "";
-	} rtd;
+	auto conn = Controller::GetInstance().GetConnection();
 
-	auto fnc = [](const void* data, const std::vector<ipc::value>& rval) {
-		ThreadData* rtd = const_cast<ThreadData*>(static_cast<const ThreadData*>(data));
-
-		if ((rval.size() == 1) && (rval[0].type == ipc::type::Null)) {
-			rtd->error_code = ErrorCode::Error;
-			rtd->error_string = rval[0].value_str;
-			rtd->called = true;
-			rtd->cv.notify_all();
-			return;
-		}
-
-		rtd->error_code = (ErrorCode)rval[0].value_union.ui64;
-		if (rtd->error_code != ErrorCode::Ok) {
-			rtd->error_string = rval[1].value_str;
-		}
-
-		rtd->called = true;
-		rtd->cv.notify_all();
-	};
-
-	bool suc = Controller::GetInstance().GetConnection()->call("Scene", "MoveItem",
-		std::vector<ipc::value>{ipc::value(scene->sourceId), ipc::value(from), ipc::value(to)}, fnc, &rtd);
-	if (!suc) {
-		info.GetIsolate()->ThrowException(
-			v8::Exception::Error(
-				Nan::New<v8::String>(
-					"Failed to make IPC call, verify IPC status."
-					).ToLocalChecked()
-			));
-		return;
-	}
-
-	std::unique_lock<std::mutex> ulock(rtd.mtx);
-	rtd.cv.wait(ulock, [&rtd]() { return rtd.called; });
-
-	if (rtd.error_code != ErrorCode::Ok) {
-		if (rtd.error_code == ErrorCode::InvalidReference) {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::ReferenceError(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		} else {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::Error(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		}
-		return;
-	}
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "MoveItem",
+		std::vector<ipc::value>{ipc::value(scene->sourceId), ipc::value(from), ipc::value(to)});
+	
+	ASSERT_RESPONSE_VALID(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::Scene::GetItemAtIndex(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -762,67 +282,16 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::GetItemAtIndex(Nan::NAN_METHOD_ARGS_TYPE
 	ASSERT_INFO_LENGTH(info, 1);
 	ASSERT_GET_VALUE(info[0], index);
 
-	struct ThreadData {
-		std::condition_variable cv;
-		std::mutex mtx;
-		bool called = false;
-		ErrorCode error_code = ErrorCode::Ok;
-		std::string error_string = "";
+	auto conn = Controller::GetInstance().GetConnection();
 
-		uint64_t id;
-	} rtd;
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "GetItem",
+		std::vector<ipc::value>{ipc::value(scene->sourceId), ipc::value(index)});
 
-	auto fnc = [](const void* data, const std::vector<ipc::value>& rval) {
-		ThreadData* rtd = const_cast<ThreadData*>(static_cast<const ThreadData*>(data));
+	ASSERT_RESPONSE_VALID(response);
 
-		if ((rval.size() == 1) && (rval[0].type == ipc::type::Null)) {
-			rtd->error_code = ErrorCode::Error;
-			rtd->error_string = rval[0].value_str;
-			rtd->called = true;
-			rtd->cv.notify_all();
-			return;
-		}
+	uint64_t id = response[1].value_union.ui64;
 
-		rtd->error_code = (ErrorCode)rval[0].value_union.ui64;
-		if (rtd->error_code != ErrorCode::Ok) {
-			rtd->error_string = rval[1].value_str;
-		}
-
-		rtd->id = rval[1].value_union.ui64;
-		rtd->called = true;
-		rtd->cv.notify_all();
-	};
-
-	bool suc = Controller::GetInstance().GetConnection()->call("Scene", "GetItem",
-		std::vector<ipc::value>{ipc::value(scene->sourceId), ipc::value(index)}, fnc, &rtd);
-	if (!suc) {
-		info.GetIsolate()->ThrowException(
-			v8::Exception::Error(
-				Nan::New<v8::String>(
-					"Failed to make IPC call, verify IPC status."
-					).ToLocalChecked()
-			));
-		return;
-	}
-
-	std::unique_lock<std::mutex> ulock(rtd.mtx);
-	rtd.cv.wait(ulock, [&rtd]() { return rtd.called; });
-
-	if (rtd.error_code != ErrorCode::Ok) {
-		if (rtd.error_code == ErrorCode::InvalidReference) {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::ReferenceError(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		} else {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::Error(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		}
-		return;
-	}
-
-	// Create new SceneItem
-	osn::SceneItem* obj = new osn::SceneItem(rtd.id);
+	osn::SceneItem* obj = new osn::SceneItem(id);
 	info.GetReturnValue().Set(osn::SceneItem::Store(obj));
 }
 
@@ -832,75 +301,20 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::GetItems(Nan::NAN_METHOD_ARGS_TYPE info)
 		return;
 	}
 
-	struct ThreadData {
-		std::condition_variable cv;
-		std::mutex mtx;
-		bool called = false;
-		ErrorCode error_code = ErrorCode::Ok;
-		std::string error_string = "";
+	auto conn = Controller::GetInstance().GetConnection();
 
-		std::list<uint64_t> ids;
-	} rtd;
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "GetItems",
+		std::vector<ipc::value>{ipc::value(scene->sourceId)});
 
-	auto fnc = [](const void* data, const std::vector<ipc::value>& rval) {
-		ThreadData* rtd = const_cast<ThreadData*>(static_cast<const ThreadData*>(data));
+	ASSERT_RESPONSE_VALID(response);
 
-		if ((rval.size() == 1) && (rval[0].type == ipc::type::Null)) {
-			rtd->error_code = ErrorCode::Error;
-			rtd->error_string = rval[0].value_str;
-			rtd->called = true;
-			rtd->cv.notify_all();
-			return;
-		}
+	auto arr = Nan::New<v8::Array>(response.size() - 1);
 
-		rtd->error_code = (ErrorCode)rval[0].value_union.ui64;
-		if (rtd->error_code != ErrorCode::Ok) {
-			rtd->error_string = rval[1].value_str;
-		}
-
-		for (size_t idx = 1; idx < rval.size(); idx++) {
-			rtd->ids.push_back(rval[idx].value_union.ui64);
-		}
-
-		rtd->called = true;
-		rtd->cv.notify_all();
-	};
-
-	bool suc = Controller::GetInstance().GetConnection()->call("Scene", "GetItems",
-		std::vector<ipc::value>{ipc::value(scene->sourceId)}, fnc, &rtd);
-	if (!suc) {
-		info.GetIsolate()->ThrowException(
-			v8::Exception::Error(
-				Nan::New<v8::String>(
-					"Failed to make IPC call, verify IPC status."
-					).ToLocalChecked()
-			));
-		return;
+	for (size_t i = 1; i < response.size(); i++) {
+		osn::SceneItem* obj = new osn::SceneItem(response[i].value_union.ui64);
+		Nan::Set(arr, i - 1, osn::SceneItem::Store(obj));
 	}
 
-	std::unique_lock<std::mutex> ulock(rtd.mtx);
-	rtd.cv.wait(ulock, [&rtd]() { return rtd.called; });
-
-	if (rtd.error_code != ErrorCode::Ok) {
-		if (rtd.error_code == ErrorCode::InvalidReference) {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::ReferenceError(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		} else {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::Error(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		}
-		return;
-	}
-
-	auto arr = Nan::New<v8::Array>(rtd.ids.size());
-	auto iter = rtd.ids.begin();
-	for (int idx = 0; idx < rtd.ids.size(); idx++) {
-		osn::SceneItem* obj = new osn::SceneItem(*iter);
-		Nan::Set(arr, idx, osn::SceneItem::Store(obj));
-		iter++;
-	}
 	info.GetReturnValue().Set(arr);
 }
 
@@ -915,75 +329,21 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::GetItemsInRange(Nan::NAN_METHOD_ARGS_TYP
 	ASSERT_GET_VALUE(info[0], from);
 	ASSERT_GET_VALUE(info[1], to);
 
-	struct ThreadData {
-		std::condition_variable cv;
-		std::mutex mtx;
-		bool called = false;
-		ErrorCode error_code = ErrorCode::Ok;
-		std::string error_string = "";
+	auto conn = Controller::GetInstance().GetConnection();
 
-		std::list<uint64_t> ids;
-	} rtd;
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "GetItemsInRange",
+		std::vector<ipc::value>{ipc::value(scene->sourceId), ipc::value(from), ipc::value(to)});
 
-	auto fnc = [](const void* data, const std::vector<ipc::value>& rval) {
-		ThreadData* rtd = const_cast<ThreadData*>(static_cast<const ThreadData*>(data));
+	ASSERT_RESPONSE_VALID(response);
+	
+	auto arr = Nan::New<v8::Array>(response.size() - 1);
 
-		if ((rval.size() == 1) && (rval[0].type == ipc::type::Null)) {
-			rtd->error_code = ErrorCode::Error;
-			rtd->error_string = rval[0].value_str;
-			rtd->called = true;
-			rtd->cv.notify_all();
-			return;
-		}
-
-		rtd->error_code = (ErrorCode)rval[0].value_union.ui64;
-		if (rtd->error_code != ErrorCode::Ok) {
-			rtd->error_string = rval[1].value_str;
-		}
-
-		for (size_t idx = 1; idx < rval.size(); idx++) {
-			rtd->ids.push_back(rval[idx].value_union.ui64);
-		}
-
-		rtd->called = true;
-		rtd->cv.notify_all();
-	};
-
-	bool suc = Controller::GetInstance().GetConnection()->call("Scene", "GetItemsInRange",
-		std::vector<ipc::value>{ipc::value(scene->sourceId), ipc::value(from), ipc::value(to)}, fnc, &rtd);
-	if (!suc) {
-		info.GetIsolate()->ThrowException(
-			v8::Exception::Error(
-				Nan::New<v8::String>(
-					"Failed to make IPC call, verify IPC status."
-					).ToLocalChecked()
-			));
-		return;
+	for (size_t i = 1; i < response.size(); i++) {
+		osn::SceneItem* obj = new osn::SceneItem(response[i].value_union.ui64);
+		Nan::Set(arr, i - 1, osn::SceneItem::Store(obj));
 	}
 
-	std::unique_lock<std::mutex> ulock(rtd.mtx);
-	rtd.cv.wait(ulock, [&rtd]() { return rtd.called; });
-
-	if (rtd.error_code != ErrorCode::Ok) {
-		if (rtd.error_code == ErrorCode::InvalidReference) {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::ReferenceError(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		} else {
-			info.GetIsolate()->ThrowException(
-				v8::Exception::Error(Nan::New<v8::String>(
-					rtd.error_string).ToLocalChecked()));
-		}
-		return;
-	}
-
-	auto arr = Nan::New<v8::Array>(rtd.ids.size());
-	auto iter = rtd.ids.begin();
-	for (int idx = 0; idx < rtd.ids.size(); idx++) {
-		osn::SceneItem* obj = new osn::SceneItem(*iter);
-		Nan::Set(arr, idx, osn::SceneItem::Store(obj));
-		iter++;
-	}
+	info.GetReturnValue().Set(arr);
 }
 
 /**

--- a/obs-studio-client/source/scene.cpp
+++ b/obs-studio-client/source/scene.cpp
@@ -71,14 +71,15 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::Create(Nan::NAN_METHOD_ARGS_TYPE info) {
 	ASSERT_INFO_LENGTH(info, 1);
 	ASSERT_GET_VALUE(info[0], name);
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper(
 		"Scene", "Create",
 		std::vector<ipc::value>{ ipc::value(name) }
 	);
 
-	ASSERT_RESPONSE_VALID(response);
+	if (!ValidateResponse(response)) return;
 
 	uint64_t sourceId = response[1].value_union.ui64;
 
@@ -93,12 +94,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::CreatePrivate(Nan::NAN_METHOD_ARGS_TYPE 
 	ASSERT_INFO_LENGTH(info, 1);
 	ASSERT_GET_VALUE(info[0], name);
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "CreatePrivate",
 		std::vector<ipc::value>{ ipc::value(name) });
 
-	ASSERT_RESPONSE_VALID(response);
+	if (!ValidateResponse(response)) return;
 
 	uint64_t sourceId = response[1].value_union.ui64;
 
@@ -112,12 +114,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::FromName(Nan::NAN_METHOD_ARGS_TYPE info)
 	ASSERT_INFO_LENGTH(info, 1);
 	ASSERT_GET_VALUE(info[0], name);
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "FromName",
 		{ ipc::value(name) });
 
-	ASSERT_RESPONSE_VALID(response);
+	if (!ValidateResponse(response)) return;
 
 	uint64_t sourceId = response[1].value_union.ui64;
 
@@ -131,12 +134,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::Release(Nan::NAN_METHOD_ARGS_TYPE info) 
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "Release",
 		std::vector<ipc::value>{ipc::value(source->sourceId)});
 
-	ASSERT_RESPONSE_VALID(response);
+	ValidateResponse(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::Scene::Remove(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -145,12 +149,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::Remove(Nan::NAN_METHOD_ARGS_TYPE info) {
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "Remove",
 		std::vector<ipc::value>{ipc::value(source->sourceId)});
 
-	ASSERT_RESPONSE_VALID(response);
+	if (!ValidateResponse(response)) return;
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::Scene::AsSource(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -177,12 +182,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::Duplicate(Nan::NAN_METHOD_ARGS_TYPE info
 	ASSERT_GET_VALUE(info[0], name);
 	ASSERT_GET_VALUE(info[1], duplicate_type);
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "Duplicate",
 		std::vector<ipc::value>{ipc::value(source->sourceId), ipc::value(name), ipc::value(duplicate_type)});
 
-	ASSERT_RESPONSE_VALID(response);
+	if (!ValidateResponse(response)) return;
 
 	uint64_t sourceId = response[1].value_union.ui64;
 
@@ -202,12 +208,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::AddSource(Nan::NAN_METHOD_ARGS_TYPE info
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "AddSource",
 		std::vector<ipc::value>{ipc::value(scene->sourceId), ipc::value(input->sourceId)});
 
-	ASSERT_RESPONSE_VALID(response);
+	if (!ValidateResponse(response)) return;
 
 	uint64_t id = response[1].value_union.ui64;
 
@@ -238,13 +245,14 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::FindItem(Nan::NAN_METHOD_ARGS_TYPE info)
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "FindItem",
 		std::vector<ipc::value>{ipc::value(scene->sourceId),
 		(haveName ? ipc::value(name) : ipc::value(position))});
 
-	ASSERT_RESPONSE_VALID(response);
+	if (!ValidateResponse(response)) return;
 
 	uint64_t id = response[1].value_union.ui64;
 
@@ -263,12 +271,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::MoveItem(Nan::NAN_METHOD_ARGS_TYPE info)
 	ASSERT_GET_VALUE(info[0], from);
 	ASSERT_GET_VALUE(info[1], to);
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "MoveItem",
 		std::vector<ipc::value>{ipc::value(scene->sourceId), ipc::value(from), ipc::value(to)});
 	
-	ASSERT_RESPONSE_VALID(response);
+	ValidateResponse(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::Scene::GetItemAtIndex(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -282,12 +291,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::GetItemAtIndex(Nan::NAN_METHOD_ARGS_TYPE
 	ASSERT_INFO_LENGTH(info, 1);
 	ASSERT_GET_VALUE(info[0], index);
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "GetItem",
 		std::vector<ipc::value>{ipc::value(scene->sourceId), ipc::value(index)});
 
-	ASSERT_RESPONSE_VALID(response);
+	if (!ValidateResponse(response)) return;
 
 	uint64_t id = response[1].value_union.ui64;
 
@@ -301,12 +311,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::GetItems(Nan::NAN_METHOD_ARGS_TYPE info)
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "GetItems",
 		std::vector<ipc::value>{ipc::value(scene->sourceId)});
 
-	ASSERT_RESPONSE_VALID(response);
+	if (!ValidateResponse(response)) return;
 
 	auto arr = Nan::New<v8::Array>(response.size() - 1);
 
@@ -329,12 +340,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::GetItemsInRange(Nan::NAN_METHOD_ARGS_TYP
 	ASSERT_GET_VALUE(info[0], from);
 	ASSERT_GET_VALUE(info[1], to);
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "GetItemsInRange",
 		std::vector<ipc::value>{ipc::value(scene->sourceId), ipc::value(from), ipc::value(to)});
 
-	ASSERT_RESPONSE_VALID(response);
+	if (!ValidateResponse(response)) return;
 	
 	auto arr = Nan::New<v8::Array>(response.size() - 1);
 

--- a/obs-studio-client/source/sceneitem.cpp
+++ b/obs-studio-client/source/sceneitem.cpp
@@ -15,17 +15,18 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301, USA.
 
-#include "sceneitem.hpp"
-#include "shared.hpp"
-#include "utility.hpp"
-#include "error.hpp"
-#include "controller.hpp"
-#include "ipc-value.hpp"
 #include <string>
 #include <condition_variable>
 #include <mutex>
+
+#include "sceneitem.hpp"
+#include "error.hpp"
+#include "controller.hpp"
+#include "ipc-value.hpp"
 #include "input.hpp"
 #include "scene.hpp"
+#include "shared.hpp"
+#include "utility.hpp"
 
 osn::SceneItem::SceneItem(uint64_t id) {
 	this->itemId = id;
@@ -76,12 +77,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetSource(Nan::NAN_METHOD_ARGS_TYPE 
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetSource",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response);
+	if (!ValidateResponse(response)) return;
 	uint64_t sourceId = response[1].value_union.ui64;
 
 	osn::Input* obj = new osn::Input(sourceId);
@@ -94,12 +96,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetScene(Nan::NAN_METHOD_ARGS_TYPE i
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetScene",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response);
+	if (!ValidateResponse(response)) return;
 	uint64_t sourceId = response[1].value_union.ui64;
 
 	osn::Scene* obj = new osn::Scene(sourceId);
@@ -112,12 +115,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::Remove(Nan::NAN_METHOD_ARGS_TYPE inf
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "Remove",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response);
+	if (!ValidateResponse(response)) return;
 	item->itemId = UINT64_MAX;
 }
 
@@ -127,12 +131,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::IsVisible(Nan::NAN_METHOD_ARGS_TYPE 
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "IsVisible",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response);
+	if (!ValidateResponse(response)) return;
 	bool flag = !!response[1].value_union.ui32;
 
 	info.GetReturnValue().Set(flag);
@@ -148,12 +153,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::SetVisible(Nan::NAN_METHOD_ARGS_TYPE
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "SetVisible",
 		std::vector<ipc::value>{ipc::value(item->itemId), ipc::value(visible)});
 
-	ASSERT_RESPONSE_VALID(response)
+	ValidateResponse(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::IsSelected(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -162,12 +168,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::IsSelected(Nan::NAN_METHOD_ARGS_TYPE
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "IsSelected",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response)
+	if (!ValidateResponse(response)) return;
 	bool flag = !!response[1].value_union.ui32;
 
 	info.GetReturnValue().Set(flag);
@@ -183,12 +190,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::SetSelected(Nan::NAN_METHOD_ARGS_TYP
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "SetSelected",
 		std::vector<ipc::value>{ipc::value(item->itemId), ipc::value(visible)});
 
-	ASSERT_RESPONSE_VALID(response)
+	ValidateResponse(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetPosition(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -197,12 +205,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetPosition(Nan::NAN_METHOD_ARGS_TYP
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetPosition",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response)
+	if (!ValidateResponse(response)) return;
 	float x = response[1].value_union.fp32;
 	float y = response[2].value_union.fp32;
 
@@ -227,12 +236,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::SetPosition(Nan::NAN_METHOD_ARGS_TYP
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "SetPosition",
 		std::vector<ipc::value>{ipc::value(item->itemId), ipc::value(x), ipc::value(y)});
 
-	ASSERT_RESPONSE_VALID(response)
+	ValidateResponse(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetRotation(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -241,12 +251,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetRotation(Nan::NAN_METHOD_ARGS_TYP
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetRotation",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response);
+	if (!ValidateResponse(response)) return;
 	float rotation = response[1].value_union.fp32;
 
 	info.GetReturnValue().Set(rotation);
@@ -263,12 +274,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::SetRotation(Nan::NAN_METHOD_ARGS_TYP
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "SetRotation",
 		std::vector<ipc::value>{ipc::value(item->itemId), ipc::value(vector)});
 	
-	ASSERT_RESPONSE_VALID(response)
+	ValidateResponse(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetScale(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -277,12 +289,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetScale(Nan::NAN_METHOD_ARGS_TYPE i
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetScale",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response);
+	if (!ValidateResponse(response)) return;
 	float x = response[1].value_union.fp32;
 	float y = response[2].value_union.fp32;
 
@@ -307,12 +320,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::SetScale(Nan::NAN_METHOD_ARGS_TYPE i
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "SetScale",
 		std::vector<ipc::value>{ipc::value(item->itemId), ipc::value(x), ipc::value(y)});
 
-	ASSERT_RESPONSE_VALID(response)
+	ValidateResponse(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetScaleFilter(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -321,12 +335,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetScaleFilter(Nan::NAN_METHOD_ARGS_
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetScaleFilter",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 	
-	ASSERT_RESPONSE_VALID(response);
+	if (!ValidateResponse(response)) return;
 	bool flag = !!response[1].value_union.ui32;
 
 	info.GetReturnValue().Set(flag);
@@ -342,12 +357,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::SetScaleFilter(Nan::NAN_METHOD_ARGS_
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "SetScaleFilter",
 		std::vector<ipc::value>{ipc::value(item->itemId), ipc::value(visible)});
 
-	ASSERT_RESPONSE_VALID(response)
+	ValidateResponse(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetAlignment(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -356,12 +372,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetAlignment(Nan::NAN_METHOD_ARGS_TY
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetAlignment",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response)
+	if (!ValidateResponse(response)) return;
 
 	bool flag = !!response[1].value_union.ui32;
 
@@ -378,12 +395,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::SetAlignment(Nan::NAN_METHOD_ARGS_TY
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "SetAlignment",
 		std::vector<ipc::value>{ipc::value(item->itemId), ipc::value(visible)});
 
-	ASSERT_RESPONSE_VALID(response)
+	ValidateResponse(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetBounds(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -392,12 +410,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetBounds(Nan::NAN_METHOD_ARGS_TYPE 
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetBounds",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response)
+	if (!ValidateResponse(response)) return;
 	float x = response[1].value_union.fp32;
 	float y = response[2].value_union.fp32;
 
@@ -422,12 +441,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::SetBounds(Nan::NAN_METHOD_ARGS_TYPE 
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "SetBounds",
 		std::vector<ipc::value>{ipc::value(item->itemId), ipc::value(x), ipc::value(y)});
 
-	ASSERT_RESPONSE_VALID(response)
+	ValidateResponse(response);
 }
 
 
@@ -437,12 +457,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetBoundsAlignment(Nan::NAN_METHOD_A
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetBoundsAlignment",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response)
+	if (!ValidateResponse(response)) return;
 	uint32_t bounds_alignment = response[1].value_union.ui32;
 
 	info.GetReturnValue().Set(bounds_alignment);
@@ -458,12 +479,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::SetBoundsAlignment(Nan::NAN_METHOD_A
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "SetBoundsAlignment",
 		std::vector<ipc::value>{ipc::value(item->itemId), ipc::value(visible)});
 
-	ASSERT_RESPONSE_VALID(response)
+	ValidateResponse(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetBoundsType(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -472,12 +494,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetBoundsType(Nan::NAN_METHOD_ARGS_T
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetBoundsType",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response)
+	if (!ValidateResponse(response)) return;
 	uint32_t bounds_type = response[1].value_union.ui32;
 
 	info.GetReturnValue().Set(bounds_type);
@@ -493,12 +516,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::SetBoundsType(Nan::NAN_METHOD_ARGS_T
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "SetBoundsType",
 		std::vector<ipc::value>{ipc::value(item->itemId), ipc::value(visible)});
 
-	ASSERT_RESPONSE_VALID(response)
+	ValidateResponse(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetCrop(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -507,12 +531,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetCrop(Nan::NAN_METHOD_ARGS_TYPE in
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetCrop",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response)
+	if (!ValidateResponse(response)) return;
 
 	uint32_t left = response[1].value_union.i32;
 	uint32_t top = response[2].value_union.i32;
@@ -546,12 +571,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::SetCrop(Nan::NAN_METHOD_ARGS_TYPE in
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "SetCrop",
 		std::vector<ipc::value>{ipc::value(item->itemId), ipc::value(left), ipc::value(top), ipc::value(right), ipc::value(bottom)});
 
-	ASSERT_RESPONSE_VALID(response);
+	ValidateResponse(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetTransformInfo(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -560,26 +586,16 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetTransformInfo(Nan::NAN_METHOD_ARG
 		return;
 	}
 
-	std::pair<float_t, float_t> position;
-	std::pair<float_t, float_t> scale;
-	uint32_t scaleFilter;
-	float_t rotation;
-	uint32_t alignment;
-	std::pair<float_t, float_t> bounds;
-	uint32_t boundsType;
-	uint32_t boundsAlignment;
-	std::tuple<int32_t, int32_t, int32_t, int32_t> crop;
-	float_t left, top, right, bottom;
-
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetTransformInfo",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response)
+	if (!ValidateResponse(response)) return;
 
 	/* Guess we forgot about alignment, not sure where this goes */
-	alignment = response[7].value_union.ui32;
+	uint32_t alignment = response[7].value_union.ui32;
 
 	auto positionObj = Nan::New<v8::Object>();
 	utilv8::SetObjectField(positionObj, "x", response[1].value_union.fp32);
@@ -638,12 +654,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetId(Nan::NAN_METHOD_ARGS_TYPE info
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetId",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response)
+	if (!ValidateResponse(response)) return;
 
 	uint64_t id = response[1].value_union.ui64;
 	
@@ -656,12 +673,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::MoveUp(Nan::NAN_METHOD_ARGS_TYPE inf
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "MoveUp",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response)
+	if (!ValidateResponse(response)) return;
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::MoveDown(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -670,12 +688,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::MoveDown(Nan::NAN_METHOD_ARGS_TYPE i
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "MoveDown",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response)
+	ValidateResponse(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::MoveTop(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -684,12 +703,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::MoveTop(Nan::NAN_METHOD_ARGS_TYPE in
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "MoveTop",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response)
+	ValidateResponse(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::MoveBottom(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -698,12 +718,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::MoveBottom(Nan::NAN_METHOD_ARGS_TYPE
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "MoveBottom",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response)
+	ValidateResponse(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::Move(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -716,12 +737,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::Move(Nan::NAN_METHOD_ARGS_TYPE info)
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "Move",
 		std::vector<ipc::value>{ipc::value(item->itemId), ipc::value(position)});
 
-	ASSERT_RESPONSE_VALID(response)
+	ValidateResponse(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::DeferUpdateBegin(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -730,12 +752,13 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::DeferUpdateBegin(Nan::NAN_METHOD_ARG
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "DeferUpdateBegin",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response)
+	ValidateResponse(response);
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::DeferUpdateEnd(Nan::NAN_METHOD_ARGS_TYPE info) {
@@ -744,10 +767,11 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::DeferUpdateEnd(Nan::NAN_METHOD_ARGS_
 		return;
 	}
 
-	auto conn = Controller::GetInstance().GetConnection();
+	auto conn = GetConnection();
+	if (!conn) return;
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "DeferUpdateEnd",
 		std::vector<ipc::value>{ipc::value(item->itemId)});
 
-	ASSERT_RESPONSE_VALID(response)
+	ValidateResponse(response);
 }

--- a/obs-studio-client/source/utility.hpp
+++ b/obs-studio-client/source/utility.hpp
@@ -50,3 +50,18 @@
 
 #define dstr(s) #s
 #define vstr(s) dstr(s)
+
+/* Validate the response to make sure the entire
+ * request didn't fail. */
+#define ASSERT_RESPONSE_VALID(Response) \
+        if ((Response.size() == 1) && (Response[0].type == ipc::type::Null)) { \
+                Nan::ThrowError(Nan::New<v8::String>(Response[1].value_str).ToLocalChecked()); \
+                return; \
+        } \
+        { \
+                ErrorCode error = (ErrorCode)Response[0].value_union.ui64; \
+                if (error != ErrorCode::Ok) { \
+                        Nan::ThrowError(Nan::New<v8::String>(Response[0].value_str).ToLocalChecked()); \
+                        return; \
+                } \
+        }


### PR DESCRIPTION
An example of how to reduce the large amount of redundancy in the client. This PR isn't meant to be pulled in but to show the difference in cleanliness, readability, and increased consistency in general of the code.