### PR TITLE
ci: Build electron binaries first on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,14 +8,12 @@ platform: x64
 
 environment:
   matrix:
-    - RuntimeURL: https://nodejs.org/download/release
-      RuntimeName: node
-      RuntimeVersion: v9.4.0
-
     - RuntimeURL: https://atom.io/download/atom-shell
       RuntimeName: iojs
       RuntimeVersion: v2.0.4
-
+    - RuntimeURL: https://nodejs.org/download/release
+      RuntimeName: node
+      RuntimeVersion: v9.4.0
   NodeVersion: 9
   SLBuildDirectory: streamlabs-build
   SLGenerator: Visual Studio 14 2015 Win64


### PR DESCRIPTION
This changes the order of the build matrix to always build iojs first instead of node.js. Since iojs/electron builds often matter more than the node.js builds, this should reduce the time spent waiting on AppVeyor to build and upload.