### PR TITLE
client/controller: Slight formatting and fix connect() function

### DIFF
--- a/obs-studio-client/source/controller.cpp
+++ b/obs-studio-client/source/controller.cpp
@@ -253,14 +253,17 @@ std::shared_ptr<ipc::client> Controller::host(std::string uri) {
 	return m_connection;
 }
 
-std::shared_ptr<ipc::client> Controller::connect(std::string uri) {
+std::shared_ptr<ipc::client> Controller::connect(std::string uri, std::chrono::nanoseconds timeout /*= std::chrono::seconds(5)*/) {
 	if (m_isServer)
 		return nullptr;
 
-	// Try and connect for 2 seconds.
+	if (m_connection)
+		return nullptr;
+
 	std::shared_ptr<ipc::client> cl;
-	std::chrono::high_resolution_clock::time_point l_begin = std::chrono::high_resolution_clock::now();
-	while (is_process_alive(procId) && (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - l_begin).count() <= 20)) {
+	using std::chrono::high_resolution_clock;
+	high_resolution_clock::time_point begin_time = high_resolution_clock::now();
+	while ((high_resolution_clock::now() - begin_time) <= timeout) {
 		try {
 			cl = std::make_shared<ipc::client>(uri);
 		} catch (...) {
@@ -268,8 +271,16 @@ std::shared_ptr<ipc::client> Controller::connect(std::string uri) {
 		}
 		if (cl)
 			break;
-		std::this_thread::sleep_for(std::chrono::milliseconds(50));
-	}	
+		
+		if (procId.handle != 0) {
+			// We are the owner of the server, but m_isServer is false for now.
+			if (!is_process_alive(procId)) {
+				break;
+			}
+		}
+
+		std::this_thread::sleep_for(std::chrono::milliseconds(100));
+	}
 	if (!cl) {
 		return nullptr;
 	}

--- a/obs-studio-client/source/controller.hpp
+++ b/obs-studio-client/source/controller.hpp
@@ -28,8 +28,8 @@
 #endif
 
 struct ProcessInfo {
-	uint64_t handle;
-	uint64_t id;
+	uint64_t handle = 0;
+	uint64_t id = 0;
 };
 
 class Controller {
@@ -51,7 +51,9 @@ class Controller {
 	
 	public:
 	std::shared_ptr<ipc::client> host(std::string uri);
-	std::shared_ptr<ipc::client> connect(std::string uri);
+
+	std::shared_ptr<ipc::client> connect(std::string uri, std::chrono::nanoseconds timeout = std::chrono::seconds(5));
+
 	void disconnect();
 
 	std::shared_ptr<ipc::client> GetConnection();


### PR DESCRIPTION
connect() would previously incorrectly always fail if we weren't the host. This normally wouldn't matter, but due to the fact that I'm doing tests with putting things into the renderer, this makes it impossible to connect() in them. This PR fixes this and formats it a bit nicer as well.