### PR TITLE
Rename Server to obs32/obs64 depending on architecture

### DIFF
--- a/js/module.js
+++ b/js/module.js
@@ -2,6 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const obs = require('./obs-studio-client.node');
 const path = require("path");
+const fs = require("fs");
 exports.DefaultD3D11Path = path.resolve(__dirname, `libobs-d3d11.dll`);
 exports.DefaultOpenGLPath = path.resolve(__dirname, `libobs-opengl.dll`);
 exports.DefaultDrawPluginPath = path.resolve(__dirname, `simple_draw.dll`);
@@ -86,7 +87,7 @@ function getSourcesSize(sourcesNames) {
     if (Array.isArray(sourcesNames)) {
         sourcesNames.forEach(function (sourceName) {
             const ObsInput = obs.Input.fromName(sourceName);
-            if(ObsInput) {
+            if (ObsInput) {
                 sourcesSize.push({ name: sourceName, height: ObsInput.height, width: ObsInput.width, outputFlags: ObsInput.outputFlags });
             }
         });
@@ -94,5 +95,10 @@ function getSourcesSize(sourcesNames) {
     return sourcesSize;
 }
 exports.getSourcesSize = getSourcesSize;
-obs.IPC.setServerPath(path.resolve(__dirname, `obs-studio-server.exe`).replace('app.asar', 'app.asar.unpacked'), path.resolve(__dirname).replace('app.asar', 'app.asar.unpacked'));
+if (fs.existsSync(path.resolve(__dirname, `obs64.exe`).replace('app.asar', 'app.asar.unpacked'))) {
+    obs.IPC.setServerPath(path.resolve(__dirname, `obs64.exe`).replace('app.asar', 'app.asar.unpacked'), path.resolve(__dirname).replace('app.asar', 'app.asar.unpacked'));
+}
+else {
+    obs.IPC.setServerPath(path.resolve(__dirname, `obs32.exe`).replace('app.asar', 'app.asar.unpacked'), path.resolve(__dirname).replace('app.asar', 'app.asar.unpacked'));
+}
 exports.NodeObs = obs;

--- a/js/module.ts
+++ b/js/module.ts
@@ -1,5 +1,6 @@
 const obs = require('./obs-studio-client.node');
 import * as path from 'path';
+import * as fs from 'fs';
 
 /* Convenient paths to modules */
 export const DefaultD3D11Path: string = 
@@ -1602,5 +1603,9 @@ export function getSourcesSize(sourcesNames: string[]): ISourceSize[] {
 }
 
 // Initialization and other stuff which needs local data.
-obs.IPC.setServerPath(path.resolve(__dirname, `obs-studio-server.exe`).replace('app.asar', 'app.asar.unpacked'), path.resolve(__dirname).replace('app.asar', 'app.asar.unpacked'));
+if (fs.existsSync(path.resolve(__dirname, `obs64.exe`).replace('app.asar', 'app.asar.unpacked'))) {
+	obs.IPC.setServerPath(path.resolve(__dirname, `obs64.exe`).replace('app.asar', 'app.asar.unpacked'), path.resolve(__dirname).replace('app.asar', 'app.asar.unpacked'));
+} else {
+	obs.IPC.setServerPath(path.resolve(__dirname, `obs32.exe`).replace('app.asar', 'app.asar.unpacked'), path.resolve(__dirname).replace('app.asar', 'app.asar.unpacked'));
+}
 export const NodeObs = obs;

--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -11,6 +11,9 @@ PROJECT(
 include(ExternalProject)
 include(DownloadProject)
 
+# Detect Architecture (Bitness)
+math(EXPR BITS "8*${CMAKE_SIZEOF_VOID_P}")
+
 ################################################################################
 # Compiler
 ################################################################################
@@ -226,7 +229,11 @@ TARGET_INCLUDE_DIRECTORIES(
 	${PROJECT_NAME}
 	PUBLIC ${PROJECT_INCLUDE_PATHS}
 )
-
+SET_TARGET_PROPERTIES(
+	${PROJECT_NAME}
+	PROPERTIES
+	OUTPUT_NAME "obs${BITS}"
+)
 IF(WIN32)
 	SET_TARGET_PROPERTIES(
 		${PROJECT_NAME}


### PR DESCRIPTION
This change implements the renaming of obs-studio-server to obs32 or obs64 in order to work around a possible whitelist in some audio drivers.