### PR TITLE
client/nodeobs_autoconfig: Fix memory leak and always ensure safe shutdown

### DIFF
--- a/obs-studio-client/source/nodeobs_autoconfig.hpp
+++ b/obs-studio-client/source/nodeobs_autoconfig.hpp
@@ -31,7 +31,7 @@ public:
 	Nan::Callback m_callback_function;
 
 	AutoConfig() {};
-	~AutoConfig() {};
+	~AutoConfig();
 
 	void start_async_runner();
 	void stop_async_runner();


### PR DESCRIPTION
AutoConfig would previously leak an unused object instead of properly releasing it. Additionally the destructor for the object would not guarantee that the worker and async_runner would be closed, resulting in unexpected behavior if the caller does not stop them.