### PR TITLE
project: Automatic formatting support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -28,7 +28,7 @@ IncludeCategories:
 SortIncludes: true
 
 # Alignment
-AlignAfterOpenBracket: Align
+AlignAfterOpenBracket: AlwaysBreak
 AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: true
 AlignEscapedNewlines: Left

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,100 @@
+# Basic Formatting
+BasedOnStyle: LLVM
+TabWidth: 4
+UseTab: ForIndentation
+ColumnLimit: 120
+
+# Language
+Language: Cpp
+Standard: Cpp11
+
+# Indentation
+AccessModifierOffset: 0
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+IndentCaseLabels: false
+#IndentPPDirectives: true
+IndentWidth: 4
+IndentWrappedFunctionNames: true
+NamespaceIndentation: All
+
+# Includes
+#IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '^<'
+    Priority: 1
+  - Regex: '^"'
+    Priority: 2
+SortIncludes: true
+
+# Alignment
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+# Wrapping and Breaking
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: false
+  AfterEnum: true
+#  AfterExternBlock: false
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: false
+  BeforeElse: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+#BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+Cpp11BracedListStyle: true
+
+# Spaces
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+#SpaceBeforeCpp11BracedList: false
+#SpaceBeforeCtorInitializerColon: true
+#SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+#SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+# Other
+CommentPragmas: '^(!FIXME!|!TODO!|ToDo:)'
+CompactNamespaces: false
+DisableFormat: false
+FixNamespaceComments: true
+#ForEachMacros: ''
+KeepEmptyLinesAtTheStartOfBlocks: false
+ReflowComments: false
+SortUsingDeclarations: true

--- a/.clang-format
+++ b/.clang-format
@@ -61,8 +61,8 @@ BraceWrapping:
   SplitEmptyFunction: false
   SplitEmptyRecord: false
   SplitEmptyNamespace: false
-BinPackArguments: true
-BinPackParameters: true
+BinPackArguments: false
+BinPackParameters: false
 BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: true

--- a/obs-studio-client/source/controller.cpp
+++ b/obs-studio-client/source/controller.cpp
@@ -28,7 +28,6 @@
 static std::string serverBinaryPath = "";
 static std::string serverWorkingPath = "";
 
-#pragma region Windows
 #ifdef _WIN32
 #include <windows.h>
 #include <psapi.h>
@@ -232,7 +231,6 @@ static void write_pid_file(std::string &pid_path, uint64_t pid) {
 }
 
 #endif
-#pragma endregion Windows
 
 Controller::Controller() {
 
@@ -357,7 +355,7 @@ std::shared_ptr<ipc::client> Controller::GetConnection() {
 	return m_connection;
 }
 
-#pragma region JavaScript
+
 void js_setServerPath(const v8::FunctionCallbackInfo<v8::Value>& args) {
 	auto isol = args.GetIsolate();
 	if (args.Length() == 0) {
@@ -476,4 +474,3 @@ INITIALIZER(js_ipc) {
 		exports->Set(v8::String::NewFromUtf8(exports->GetIsolate(), "IPC"), obj);
 	});
 }
-#pragma endregion JavaScript

--- a/obs-studio-client/source/controller.hpp
+++ b/obs-studio-client/source/controller.hpp
@@ -42,7 +42,6 @@ struct ProcessInfo {
 };
 
 class Controller {
-#pragma region Singleton
 	public:
 	static Controller& GetInstance() {
 		static Controller _inst;
@@ -56,7 +55,6 @@ class Controller {
 	public: // C++11
 	Controller(Controller const&) = delete;
 	void operator=(Controller const&) = delete;
-#pragma endregion Singleton
 
 	public:
 	std::shared_ptr<ipc::client> host(const std::string &uri);

--- a/obs-studio-client/source/utility-v8.hpp
+++ b/obs-studio-client/source/utility-v8.hpp
@@ -61,7 +61,6 @@
     }
 
 namespace utilv8 {
-#pragma region ToValue
 	// Integers
 	inline v8::Local<v8::Value> ToValue(bool v) {
 		return Nan::New<v8::Boolean>(v);
@@ -176,9 +175,7 @@ namespace utilv8 {
 	inline v8::Local<v8::Value> ToValue(v8::Local<v8::Function> v) {
 		return v;
 	}
-#pragma endregion ToValue
 
-#pragma region FromValue
 	// Integers
 	inline bool FromValue(v8::Local<v8::Value> l, bool& r) {
 		if (l->IsBoolean()) {
@@ -327,9 +324,7 @@ namespace utilv8 {
 		}
 		return false;
 	}
-#pragma endregion FromValue
 
-#pragma region ToArrayBuffer
 	inline v8::Local<v8::Value> ToArrayBuffer(std::vector<int8_t> v) {
 		auto rv = v8::ArrayBuffer::New(v8::Isolate::GetCurrent(), v.size() * sizeof(int8_t));
 		memcpy(rv->GetContents().Data(), v.data(), v.size());
@@ -389,9 +384,7 @@ namespace utilv8 {
 		memcpy(rv->GetContents().Data(), v.data(), v.size());
 		return v8::Float64Array::New(rv, 0, v.size());
 	}
-#pragma endregion ToArrayBuffer
 
-#pragma region Objects
 	template<typename T> inline void SetObjectField(v8::Local<v8::Object> object, const char* field, T value) {
 		Nan::Set(object, ToValue(field), ToValue(value));
 	}
@@ -419,9 +412,7 @@ namespace utilv8 {
 		Nan::FunctionCallback get, Nan::FunctionCallback set = nullptr) {
 		object->SetAccessorProperty(FIELD_NAME(name), ToValue(get), ToValue(set));
 	}
-#pragma endregion Objects
 
-#pragma region Templates
 	template<typename T> inline void SetTemplateField(v8::Local<v8::Template> object, const char* field, T value) {
 		Nan::SetMethod(object, ToValue(field), ToValue(value));
 	}
@@ -441,7 +432,6 @@ namespace utilv8 {
 	inline void SetObjectTemplateAccessor(v8::Local<v8::ObjectTemplate> object, const char *name, Nan::GetterCallback get, Nan::SetterCallback set = nullptr) {
 		Nan::SetAccessor(object, FIELD_NAME(name), get, set);
 	}
-#pragma endregion Templates
 
 	template<typename T>
 	inline bool SafeUnwrap(Nan::NAN_METHOD_ARGS_TYPE info, T*& valp) {
@@ -502,7 +492,6 @@ namespace utilv8 {
 		return std::string(*v8::String::Utf8Value(type));
 	}
 
-#pragma region Callback
 	/* This structure is an adaptation of one used in SQLite Node bindings.
 	* You can find the original here:
 	* https://github.com/mapbox/node-sqlite3/blob/master/src/async.h */
@@ -615,7 +604,6 @@ namespace utilv8 {
 						 * being executed. */
 		bool stopped;
 	};
-#pragma endregion Callback
 
 	// Template class for asynchronous v8 Callbacks
 	// 

--- a/obs-studio-server/source/gs-vertexbuffer.h
+++ b/obs-studio-server/source/gs-vertexbuffer.h
@@ -32,8 +32,7 @@ extern "C" {
 namespace GS {
 	class VertexBuffer {
 		public:
-	#pragma region Constructor & Destructor
-		virtual ~VertexBuffer();
+			virtual ~VertexBuffer();
 
 		/*!
 		* \brief Create a Vertex Buffer with a specific number of Vertices.
@@ -57,10 +56,8 @@ namespace GS {
 		*/
 		VertexBuffer(gs_vertbuffer_t* other);
 
-	#pragma endregion Constructor & Destructor
-
-	#pragma region Copy/Move Constructors
-		// Copy Constructor & Assignments
+	
+			// Copy Constructor & Assignments
 
 		/*!
 		* \brief Copy Constructor
@@ -95,8 +92,7 @@ namespace GS {
 		* \param other
 		*/
 		void operator=(VertexBuffer const&& other);
-	#pragma endregion Copy/Move Constructors
-		
+			
 
 
 		void Resize(uint32_t new_size);
@@ -153,12 +149,10 @@ namespace GS {
 		*/
 		vec4* GetUVLayer(size_t idx);
 
-	#pragma region Update / Grab GS object
-		gs_vertbuffer_t* Update();
+			gs_vertbuffer_t* Update();
 
 		gs_vertbuffer_t* Update(bool refreshGPU);
-	#pragma endregion Update / Grab GS object
-
+	
 		private:
 		uint32_t m_size;
 		uint32_t m_capacity;

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -210,7 +210,6 @@ static void DeleteOldestFile(const char *location, unsigned maxLogs)
 	}
 }
 
-#pragma region Logging
 #include <chrono>
 #include <cstdarg>
 #include <varargs.h>
@@ -353,7 +352,6 @@ static void node_obs_log(int log_level, const char *msg, va_list args, void *par
 		__debugbreak();
 #endif
 }
-#pragma endregion Logging
 
 void OBS_API::OBS_API_initAPI(void* data, const int64_t id, const std::vector<ipc::value>& args, std::vector<ipc::value>& rval) {
 	/* Map base DLLs as soon as possible into the current process space.
@@ -434,7 +432,6 @@ void OBS_API::OBS_API_initAPI(void* data, const int64_t id, const std::vector<ip
 	os_get_config_path(userData.data(), userData.capacity() - 1, "slobs-client/plugin_config");
 	obs_startup(args[1].value_str.c_str(), userData.data(), NULL);
 
-#pragma region Logging
 	/* Logging */
 	string filename = GenerateTimeDateFilename("txt");
 	string log_path = appdata_path;
@@ -468,7 +465,6 @@ void OBS_API::OBS_API_initAPI(void* data, const int64_t id, const std::vector<ip
 
 	/* Delete oldest file in the folder to imitate rotating */
 	base_set_log_handler(node_obs_log, logfile);
-#pragma endregion Logging
 
 	/* INJECT osn::Source::Manager */
 	// Alright, you're probably wondering: Why is osn code here?
@@ -762,7 +758,6 @@ void OBS_API::destroyOBS_API(void) {
 	profiler_free();*/
 }
 
-#pragma region Case-Insensitive String
 struct ci_char_traits : public char_traits<char> {
 	static bool eq(char c1, char c2) {
 		return toupper(c1) == toupper(c2);
@@ -790,7 +785,6 @@ struct ci_char_traits : public char_traits<char> {
 };
 
 typedef std::basic_string<char, ci_char_traits> istring;
-#pragma endregion Case-Insensitive String
 
 /* This should be reusable outside of node-obs, especially
 * if we go a server/client route. */

--- a/obs-studio-server/source/nodeobs_display.h
+++ b/obs-studio-server/source/nodeobs_display.h
@@ -30,7 +30,6 @@ namespace OBS {
 
 		void SystemWorker();
 
-#pragma region Constructors & Finalizer
 		private:
 		Display();
 
@@ -38,7 +37,6 @@ namespace OBS {
 		Display(uint64_t windowHandle); // Create a Main Preview one
 		Display(uint64_t windowHandle, std::string sourceName); // Create a Source-Specific one
 		~Display();
-#pragma endregion Constructors & Finalizer
 
 		void SetPosition(uint32_t x, uint32_t y);
 		std::pair<uint32_t, uint32_t> GetPosition();


### PR DESCRIPTION
This adds support for automatic formatting using clang-format in Visual Studio 2017 and Visual Studio Code. With this we have a guaranteed code style across the entire obs-studio-node project.

For an example of what this will look like, please take a look [here](https://github.com/Xaymar-Streamlabs/obs-studio-node/tree/formatting-applied). This PR replaces #61.
