### PR TITLE
Fix Server process not stopping if Clients crash

### DIFF
--- a/obs-studio-server/source/main.cpp
+++ b/obs-studio-server/source/main.cpp
@@ -185,6 +185,9 @@ int main(int argc, char* argv[]) {
 	// Initialize Server
 	try {
 		myServer.initialize(argv[1]);
+	} catch (std::exception e) {
+		std::cerr << "Initialization failed with error " << e.what() << "." << std::endl;
+		return -2;
 	} catch (...) {
 		std::cerr << "Failed to initialize server" << std::endl;
 		return -2;


### PR DESCRIPTION
A bug in lib-streamlabs-ipc and lib-datalane lead to is_connected() always returning true and the watcher not properly checking for changes. This rewrites parts of the core logic to fix the issue.