### PR TITLE
Optimize and fix headers in utility files

### DIFF
--- a/obs-studio-client/source/utility.hpp
+++ b/obs-studio-client/source/utility.hpp
@@ -17,12 +17,9 @@
 
 #pragma once
 #include <string>
-#include <inttypes.h>
-#include <vector>
-#include <node.h>
-
 #include <vector>
 #include <memory>
+
 #include <nan.h>
 
 #include "error.hpp"

--- a/obs-studio-server/source/util-memory.cpp
+++ b/obs-studio-server/source/util-memory.cpp
@@ -18,7 +18,6 @@
 */
 
 #include "util-memory.h"
-#include <cstdlib>
 
 void* util::malloc_aligned(size_t align, size_t size) {
 #if defined(_MSC_VER)

--- a/obs-studio-server/source/util-memory.h
+++ b/obs-studio-server/source/util-memory.h
@@ -18,8 +18,8 @@
  */
 
 #pragma once
-#include <stdlib.h>
-#include <malloc.h>
+#include <cstdlib>
+#include <cstddef>
 
 namespace util {
 	inline size_t aligned_offset(size_t align, size_t pos) {

--- a/obs-studio-server/source/utility.hpp
+++ b/obs-studio-server/source/utility.hpp
@@ -16,11 +16,9 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301, USA.
 
 #pragma once
-#include <inttypes.h>
 #include <list>
 #include <limits>
 #include <map>
-#include <memory>
 
 #if defined(_MSC_VER)
 #define FORCE_INLINE __forceinline


### PR DESCRIPTION
For some reason, none of the other tools noted this but this is sketchy in C++:
```
#include <stdlib.h>
#include <malloc.h>
```
This is okay in some compilers but there's no guarantee those are declared in a way that matches the exported variables (though practically speaking, it almost always does). The problem really comes around when we then do this: `typedef std::ptrdiff_t difference_type;`

I'm not sure if stdlib.h is defined to include stddef.h but either way, while using the C headers, it isn't normally put into the std namespace. For some reason, this compiles in VC++ even though the only place that's guaranteed to work is if you use cstddef (which cstdlib guarantees it will include for us).

This also fixes some other oddities like including vector twice (mostly a organizational issue since the second include is a no-op) or including things we don't use.