### PR TITLE
Revert "controller: Do not block the main process for 5sec"

### DIFF
--- a/obs-studio-client/source/controller.cpp
+++ b/obs-studio-client/source/controller.cpp
@@ -460,11 +460,14 @@ void js_connectOrHost(const v8::FunctionCallbackInfo<v8::Value>& args)
 	}
 
 	std::string uri = *v8::String::Utf8Value(args[0]);
-	auto        cl  = Controller::GetInstance().host(uri);
+	auto        cl  = Controller::GetInstance().connect(uri);
 	if (!cl) {
-		isol->ThrowException(
-		    v8::Exception::Error(Nan::New<v8::String>("IPC failed to connect or host.").ToLocalChecked()));
-		return;
+		cl = Controller::GetInstance().host(uri);
+		if (!cl) {
+			isol->ThrowException(
+			    v8::Exception::Error(Nan::New<v8::String>("IPC failed to connect or host.").ToLocalChecked()));
+			return;
+		}
 	}
 
 	return;


### PR DESCRIPTION
This reverts commit 8e10079000f87ab55cf6e5d5d917b8c7fb46844a and fixes the behavior of connectOrHost(). If you only want to connect or host, use either connect() or host() for that.

First bug discovered by the test suite. More likely to follow.