### PR TITLE
Enable QSV encoder

### DIFF
--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -1083,20 +1083,8 @@ void OBS_service::updateVideoStreamingEncoder()
 
 	if (encoder != NULL) {
 		if (strcmp(encoder, SIMPLE_ENCODER_QSV) == 0 || strcmp(encoder, ADVANCED_ENCODER_QSV) == 0) {
-			/*presetType = "QSVPreset";
-			encoderID = "obs_qsv11";*/
-
-			if (EncoderAvailable(ADVANCED_ENCODER_NVENC)) {
-				presetType = "NVENCPreset";
-				encoderID  = "ffmpeg_nvenc";
-			} else if (EncoderAvailable(SIMPLE_ENCODER_AMD)) {
-				presetType = "AMDPreset";
-				UpdateStreamingSettings_amd(h264Settings, videoBitrate);
-				encoderID = "amd_amf_h264";
-			} else {
-				presetType = "Preset";
-				encoderID  = "obs_x264";
-			}
+			presetType = "QSVPreset";
+			encoderID = "obs_qsv11";
 		} else if (strcmp(encoder, SIMPLE_ENCODER_AMD) == 0 || strcmp(encoder, ADVANCED_ENCODER_AMD) == 0) {
 			presetType = "AMDPreset";
 			UpdateStreamingSettings_amd(h264Settings, videoBitrate);

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -891,8 +891,8 @@ void OBS_settings::getSimpleAvailableEncoders(std::vector<std::pair<std::string,
 {
 	streamEncoder->push_back(std::make_pair("Software (x264)", SIMPLE_ENCODER_X264));
 
-	/*if (EncoderAvailable("obs_qsv11"))
-		streamEncoder->push_back(std::make_pair("QSV", SIMPLE_ENCODER_QSV));*/
+	if (EncoderAvailable("obs_qsv11"))
+		streamEncoder->push_back(std::make_pair("QSV", SIMPLE_ENCODER_QSV));
 
 	if (EncoderAvailable("ffmpeg_nvenc"))
 		streamEncoder->push_back(std::make_pair("NVENC", SIMPLE_ENCODER_NVENC));
@@ -905,8 +905,8 @@ void OBS_settings::getAdvancedAvailableEncoders(std::vector<std::pair<std::strin
 {
 	streamEncoder->push_back(std::make_pair("Software (x264)", ADVANCED_ENCODER_X264));
 
-	/*if (EncoderAvailable("obs_qsv11"))
-		streamEncoder->push_back(std::make_pair("QSV", ADVANCED_ENCODER_QSV));*/
+	if (EncoderAvailable("obs_qsv11"))
+		streamEncoder->push_back(std::make_pair("QSV", ADVANCED_ENCODER_QSV));
 
 	if (EncoderAvailable("ffmpeg_nvenc"))
 		streamEncoder->push_back(std::make_pair("NVENC", ADVANCED_ENCODER_NVENC));
@@ -1551,18 +1551,6 @@ SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t* config, b
 	const char* encoderID = config_get_string(config, "AdvOut", "Encoder");
 	if (encoderID == NULL) {
 		encoderID = "obs_x264";
-		config_set_string(config, "AdvOut", "Encoder", encoderID);
-		config_save_safe(config, "tmp", nullptr);
-	}
-
-	if (std::strcmp(encoderID, ADVANCED_ENCODER_QSV) == 0) {
-		if (EncoderAvailable(ADVANCED_ENCODER_NVENC)) {
-			encoderID = ADVANCED_ENCODER_NVENC;
-		} else if (EncoderAvailable(SIMPLE_ENCODER_AMD)) {
-			encoderID = SIMPLE_ENCODER_AMD;
-		} else {
-			encoderID = ADVANCED_ENCODER_X264;
-		}
 		config_set_string(config, "AdvOut", "Encoder", encoderID);
 		config_save_safe(config, "tmp", nullptr);
 	}
@@ -2816,15 +2804,6 @@ void OBS_settings::saveAdvancedOutputRecordingSettings(std::vector<SubCategory> 
 		encoderSettings = obs_encoder_defaults(config_get_string(config, section.c_str(), "RecEncoder"));
 
 	std::string currentEncoder = config_get_string(config, "AdvOut", "RecEncoder");
-	if (currentEncoder.compare(ADVANCED_ENCODER_QSV) == 0) {
-		if (EncoderAvailable(ADVANCED_ENCODER_NVENC)) {
-			encoderSettings = obs_encoder_defaults(ADVANCED_ENCODER_NVENC);
-		} else if (EncoderAvailable(SIMPLE_ENCODER_AMD)) {
-			encoderSettings = obs_encoder_defaults(SIMPLE_ENCODER_AMD);
-		} else {
-			encoderSettings = obs_encoder_defaults(ADVANCED_ENCODER_X264);
-		}
-	}
 
 	obs_encoder_update(encoder, encoderSettings);
 


### PR DESCRIPTION
I'm not sure the details of the original reason for disabling QSV. I've tested this and initial testing seems alright. I've provided a few people with a build of 10.3.0 with this patch so I guess we'll see.